### PR TITLE
Fix encrypted data for crypto fixture

### DIFF
--- a/test-resources/crypto-data-128.json
+++ b/test-resources/crypto-data-128.json
@@ -24,7 +24,7 @@
       },
       "encrypted": {
         "name": "example",
-        "data": "HO4cYSP8LybPYBPZPHQOtuB3dfKG08yw7J4qx3kkjxdW0eoZv+nGAp76OKqYQ327",
+        "data": "HO4cYSP8LybPYBPZPHQOtrLs+liDNVbBVuSFPZUMVDAycp6zusFCS2ll31w683ud",
         "encoding": "cipher+aes-128-cbc/base64"
       }
     },

--- a/test-resources/crypto-data-256.json
+++ b/test-resources/crypto-data-256.json
@@ -24,7 +24,7 @@
       },
       "encrypted": {
         "name": "example",
-        "data": "NMDl1Acnel8HVdu1cEWdr8UFEi56Ms0zPHszbppM61BC8Yf6ndq+kiCj9xXW97/O",
+        "data": "NMDl1Acnel8HVdu1cEWdrxe4S0kK8Tfj8YCc6M40xtpkkPK1os8j5JhitfAVe4XM",
         "encoding": "cipher+aes-256-cbc/base64"
       }
     },


### PR DESCRIPTION
The ciphertext for '.items | .[1].encrypted.data' was errornously
padded, which caused ably-go tests to fail on encryption tests (the
decryption was unaffected as the padding was removed either way).

The ciphertext was (in bytes):

  0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15

Which got padded to:

  0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 16 16 16 16 16 16 16 16 16 16
16 16 16 16 16

And such data was encrypted in the old version. This CL changes the
encrypted data to the one created for the ciphertext without padding.