### PR TITLE
Prefix duplicate keys

### DIFF
--- a/test-resources/test-app-setup.json
+++ b/test-resources/test-app-setup.json
@@ -1,5 +1,5 @@
 {
-  "post_apps": "/* JSON body using in POST sandbox-rest.ably.io/apps request to set up the Test app */",
+  "_post_apps": "/* JSON body using in POST sandbox-rest.ably.io/apps request to set up the Test app */",
   "post_apps": {
     "keys": [
       {},
@@ -29,7 +29,7 @@
     ]
   },
 
-  "cipher": "/* Cipher configuration for client_encoded presence fixture data used in REST tests */",
+  "_cipher": "/* Cipher configuration for client_encoded presence fixture data used in REST tests */",
   "cipher": {
     "algorithm": "aes",
     "mode": "cbc",


### PR DESCRIPTION
We don't need the values of the comments in the duplicate keys for `post_apps` and `cipher`, and they can actually break some JSON libraries as the JSON specification doesn't really define any behavior with regards to duplicate keys. Since we don't need them to be machine-readable, just prefix with an underscore to avoid key clashes.