### PR TITLE
Support configurable presence member limit for tests

### DIFF
--- a/test-resources/test-app-setup.json
+++ b/test-resources/test-app-setup.json
@@ -1,6 +1,7 @@
 {
   "_post_apps": "/* JSON body using in POST sandbox-rest.ably.io/apps request to set up the Test app */",
   "post_apps": {
+    "limits": { "presence": { "maxMembers": 250 } },
     "keys": [
       {},
       {


### PR DESCRIPTION
The default limit of 50/100 is not good enough for testing as a single
presence page contains up to 100 members.  For client libs to test
paging >100 members are needed.