### PR TITLE
authUrl and authCallback failure error code

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -88,6 +88,7 @@
 	"80016": "operation on superseded transport",
 	"80017": "connection closed",
 	"80018": "invalid connection id (invalid format)",
+	"80019": "client configured authentication provider request failed",
 	"80020": "maximum connection message rate exceeded (publish)",
 	"80021": "maximum connection message rate exceeded (subscribe)",
 	"80030": "client restriction not satisfied",


### PR DESCRIPTION
@paddybyers a quick attempt an error code relating to a connection attempt failing due to the auth provider failing.  See https://github.com/ably/docs/pull/132
