### PR TITLE
Channel operation timed out error for (RTL3d)

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -100,6 +100,7 @@
 	"90004": "unable to recover channel (message limit exceeded)",
 	"90005": "unable to recover channel (no matching epoch)",
 	"90006": "unable to recover channel (unbounded request)",
+	"90007": "channel operation failed (timed out)",
 	"91000": "unable to enter presence channel (no clientId)",
 	"91001": "unable to enter presence channel (invalid channel state)",
 	"91002": "unable to leave presence channel that is not entered",

--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -100,7 +100,7 @@
 	"90004": "unable to recover channel (message limit exceeded)",
 	"90005": "unable to recover channel (no matching epoch)",
 	"90006": "unable to recover channel (unbounded request)",
-	"90007": "channel operation failed (timed out)",
+	"90007": "channel operation failed (no response from server)",
 	"91000": "unable to enter presence channel (no clientId)",
 	"91001": "unable to enter presence channel (invalid channel state)",
 	"91002": "unable to leave presence channel that is not entered",


### PR DESCRIPTION
@paddybyers are you happy for me to add this error code that I can emit when a channel attach/detach operation fails? See https://github.com/ably/docs/commit/a135a4009ef93b66c042dc73c8e9ff5a2ce033c8#diff-11900b395df266bc2bbfc1d11bdfc7a0R394