### PR TITLE
add code for siege mode rejection

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -60,6 +60,7 @@
 	"50001": "internal channel error",
 	"50002": "internal connection error",
 	"50003": "timeout error",
+	"50004": "Request failed due to overloaded instance",
 
 	/* frontend connection-related */
 	"55000": "internal error (uncategorised)",


### PR DESCRIPTION
https://github.com/ably/realtime/pull/1010#discussion_r110709746

(that comment requested "a set of siege related errors" - not sure what you were imagining? could define different codes for connection/channel/rest-request/etc, but seems a bit unnecessary as there's no ambiguity, it's not like you could get the connection one in a DETACHED etc)