### PR TITLE
Generalise 'webhook' codes to 'reactor'; add 70003 max concurrency exceeded

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -61,13 +61,11 @@
 	"50002": "internal connection error",
 	"50003": "timeout error",
 
-	/* webhook-related */
-	"70000": "webhook operation failed",
-	"70001": "webhook operation failed (post operation failed)",
-	"70002": "webhook operation failed (post operation returned unexpected code)",
-	"70003": "unable to recover channel (messages expired)",
-	"70004": "unable to recover channel (message limit exceeded)",
-	"70005": "unable to recover channel (history incomplete)",
+	/* reactor-related */
+	"70000": "reactor operation failed",
+	"70001": "reactor operation failed (post operation failed)",
+	"70002": "reactor operation failed (post operation returned unexpected code)",
+	"70003": "reactor operation failed (maximum number of concurrent in-flight requests exceeded)",
 
 	/* connection-related */
 	"80000": "connection failed",


### PR DESCRIPTION
removing the previous 70003-5 as don't make sense as reactor error codes