### PR TITLE
Adding error code 40018

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -21,6 +21,7 @@
 	"40015": "Invalid device id",
 	"40016": "Invalid message name",
 	"40017": "Unsupported protocol version",
+	"40018": "Unable to decode message; channel attachment no longer viable",
 	"40020": "Batch error",
 	"40030": "Invalid publish request (unspecified)",
 	"40031": "Invalid publish request (invalid client-specified id)",


### PR DESCRIPTION
Error code 40018 is used to describe message decode failure. Reattach is the intended failure recovery strategy. At the time of writing this, the code is used only by the ably delta codecs on delta application failure.