### PR TITLE
suppress delta extras: add error code for messages with impermissible…

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -27,6 +27,7 @@
 	"40021": "Feature requires a newer platform version",
 	"40030": "Invalid publish request (unspecified)",
 	"40031": "Invalid publish request (invalid client-specified id)",
+	"40032": "Invalid publish request (impermissible extras field)",
 	"40099": "Reserved for artifical errors for testing",
 
 	/* 401 codes */


### PR DESCRIPTION
Added error code 40032, for messages with extras fields that are not permitted.