### PR TITLE
Add 42200 Unprocessable Entity code

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -78,6 +78,9 @@
 	/* 410 codes */
 	"41001": "push device registration expired",
 
+	/* 422 codes */
+	"42200": "Unprocessable entity",
+
 	/* 429 codes */
 	"42910": "rate limit exceeded (nonfatal): request rejected (unspecified)",
 	"42911": "max per-connection publish rate limit exceeded (nonfatal): unable to publish message",


### PR DESCRIPTION
Support `422 Unprocessable Entity` errors.

> the server understands the content type of the request entity, and the syntax of the request entity is correct, but it was unable to process the contained instructions.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422