### PR TITLE
Fix setting git config in GitHub publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,6 @@ jobs:
 
       - name: Publish to Repositories
         run: |
-          git config user.name "ably-common-publish-action"
-          git config user.email "ably-common-publish-action@ably.com"
+          git config --global user.name "ably-common-publish-action"
+          git config --global user.email "ably-common-publish-action@ably.com"
           scripts/publish.sh


### PR DESCRIPTION
The git config needs to be set globally, apparently.

With this change, I've now successfully run the publish action from this branch, see https://github.com/ably/ably-common-go/commit/8a93fe1bbf615bb91d736f0419598f172c6a89d7 🚀 