### PR TITLE
Add JRE to agents

### DIFF
--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -95,7 +95,7 @@
             "emitters": [
                 "ably-java"
             ],
-            "type": "sdk"
+            "type": "runtime"
         },
         {
             "identifier": "android",

--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -90,6 +90,14 @@
             "type": "sdk"
         },
         {
+            "identifier": "jre",
+            "versioned": true,
+            "emitters": [
+                "ably-java"
+            ],
+            "type": "sdk"
+        },
+        {
             "identifier": "android",
             "versioned": true,
             "emitters": [


### PR DESCRIPTION
Added `jre` to the agents. This will be emitted from the `ably-java` library.