### PR TITLE
Expand commentary around demo repositories

### DIFF
--- a/templates/sdk-readme.md
+++ b/templates/sdk-readme.md
@@ -44,6 +44,9 @@ Examples:
 [ably-flutter](https://github.com/ably/ably-flutter#resources),
 [ably-asset-tracking-android](https://github.com/ably/ably-asset-tracking-android/blob/main/README.md#useful-resources)
 
+Demo repositories are mostly hosted in our [ably-labs](https://github.com/ably-labs) GitHub org.
+New demos should be indexed from the SDK repositories upon which they depend, under this heading.
+
 ## Requirements
 
 What is required to build a project using this SDK. Typically a list of prerequisites.


### PR DESCRIPTION
We had some interesting conversation in our internal company meeting on Friday around demos and Ably use case examples.

What became apparent is that there are some valuable demos coming out of our developer relations team which need to be made more visible to those visiting our client library SDK repositories. This pull request attempts to make that a bit clearer.