### PR TITLE
Fix the emitter for Asset Tracking Android

### DIFF
--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -137,7 +137,7 @@
             "identifier": "ably-asset-tracking-android",
             "versioned": true,
             "emitters": [
-                "ably-java"
+                "ably-asset-tracking-android"
             ],
             "type": "wrapper"
         },


### PR DESCRIPTION
Now that we've clarified the intended purpose of `emitters` - see https://github.com/ably/ably-common/pull/109.