### PR TITLE
Add GitHub labels

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,11 +11,12 @@ jobs:
       - uses: actions/checkout@v2
 
       # Using git grep to fail the build if any tab characters are found in source files (except Go files) - we use spaces for whitespace.
-      # Using prettier to ensure JSON files have consistent formatting.
+      # Using prettier to ensure JSON and YAML files have consistent formatting.
       - run: |
           ! git --no-pager grep $'\t' -- './*' ':!./go' || { echo 'ERROR: Lint failed! Source files must use spaces for whitespace.'; false; }
           npm ci
           npx prettier --check "**/*.json"
+          npx prettier --check "**/*.yml"
           npm test
 
   check-go:
@@ -26,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.5'
+          go-version: "1.16.5"
 
       - name: Build for Go users
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.5'
+          go-version: "1.16.5"
 
       - name: Setup SSH access
         uses: webfactory/ssh-agent@v0.5.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,18 @@ If you want to be sure that changes you make to JSON files will not fail CI then
 
     npx prettier --write "**/*.json"
 
+### YAML Files
+
+As for JSON files (see above) we also use Prettier to ensure YAML is conformed.
+
+You can ask Prettier to rewrite incorrectly formatted YAML files with this command:
+
+    npx prettier --write "**/*.yml"
+
+**Note**:
+This invocation, matching what we do in the CI workflow, naturally includes our [GitHub workflow source files](.github/workflows) too.
+That is intentional.
+
 ## Release Process
 
 The outputs from this repository are not yet versioned, though this is planned ([#70](https://github.com/ably/ably-common/issues/70)).

--- a/github/labels.yml
+++ b/github/labels.yml
@@ -1,4 +1,3 @@
----
 api:
   description: Something that will change or improve the public API.
   color: ec4b42

--- a/github/labels.yml
+++ b/github/labels.yml
@@ -1,0 +1,31 @@
+---
+api:
+  description: Something that will change or improve the public API.
+  color: ec4b42
+bug:
+  description: Something isn't working. It's clear that this does need to be fixed.
+  color: d73a4a
+clarification-required:
+  description: This issue needs more detail.
+  color: e3d79b
+code-quality:
+  description: Affects the developer experience when working in our codebase.
+  color: ff88cc
+consistency:
+  description: Relates to ecosystem-level compatibility across implementations.
+  color: f4c45c
+documentation:
+  description: Improvements or additions to public interface documentation (API reference or readme).
+  color: 0075ca
+enhancement:
+  description: New feature or request.
+  color: a2eeef
+example-app:
+  description: Relates to the example apps included in this repository.
+  color: 70fc6b
+failing-test:
+  description: Where a test is failing either locally or in CI. Perhaps flakey (badly written), wrong or bug.
+  color: ff8888
+important:
+  description: We should try not to overuse this label, but it's a quick way to lightly mark as higher priority.
+  color: b60205


### PR DESCRIPTION
### Immediate Value Delivered

The primary focus of this pull request is to add `github/labels.yml` as an initial import for a canonical location for us to document the GitHub labels we're using across our open source SDK repositories.

The contents of this file will evolve over time, both in terms of adding new labels, modifying the ones that have been defined here, and perhaps even by adding new keys. The keys defined so far - being the name (top-level key, implicit), `description` and `color` - closely match what's defined in GitHub.

### Future Plan

A later development, potentially in this codebase but perhaps in a new codebase (yet to be defined) downstream of this one, is that we will use this file as source input to a script that uses GitHub's GraphQL REST API to validate labels defined across all of our repositories (as part of SDK monitoring / auditing / conforming initiative).

Much of this future is in my head right now (early ideation / R&D / prototyping stage) - so feel free to reach out to me directly if you would like more information on that.

### Why Add YAML?

The choice of YAML for this file, adding to the file formats utilised by this repository, is intentional and partially experimental:

- This is **source code**: For human maintainers of this file, YAML is a lighter weight format that should be easier to wrangle in most editors.
- This can be transformed for **downstream consumption** (packaging / distribution): There is tooling readily available to convert from YAML to JSON, for example.

Thus, fixes #108.