### PR TITLE
Replacing third-party action with bash

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,12 @@ jobs:
           go-version: "1.16.5"
 
       - name: Setup SSH access
-        uses: webfactory/ssh-agent@v0.5.3
-        with:
-          ssh-private-key: ${{ secrets.ABLY_COMMON_GO_SSH_KEY }}
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.ABLY_COMMON_GO_SSH_KEY }}
+        run: |
+          echo "$SSH_PRIVATE_KEY" > ssh-private-key.pem
+          eval $(ssh-agent -s)
+          ssh-add ssh-private-key.pem
 
       - name: Build and then Publish to Downstream Repository for Go users
         run: |


### PR DESCRIPTION
This came out of a conversation @lmars and myself had this morning. The third-party action could potentially leak the private key outside of the workflow runner.

At the time of writing this comment, this modification is not yet proven (we need to run this workflow manually).