### PR TITLE
Add versions for clientEvent JSON schemas

### DIFF
--- a/json-schemas/README.md
+++ b/json-schemas/README.md
@@ -20,6 +20,17 @@ publish time (see below).
 
 ## Publish
 
+Set the `SDK_S3_ACCESS_KEY_ID` and `SDK_S3_ACCESS_KEY` environment variables to
+an AWS access key and secret that has write permissions to the `schemas.ably.com`
+S3 bucket in the SDK AWS account. If you are a SuperAdmin in the SDK AWS account,
+then run the following:
+
+```
+source <(ably-env secrets print-aws --account sdk --role SuperAdmin)
+export SDK_S3_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+export SDK_S3_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+```
+
 Run `npm run publish:json-schemas`.
 
 See `publish.js` for more information.

--- a/json-schemas/versions.json
+++ b/json-schemas/versions.json
@@ -1,4 +1,6 @@
 {
   "agents": "0.0.1",
-  "app-stats": "0.0.1"
+  "app-stats": "0.0.1",
+  "client-events-api-requests": "0.0.1",
+  "client-events-connections": "0.0.1"
 }


### PR DESCRIPTION
As per the [JSON schema docs](https://github.com/ably/ably-common/tree/main/json-schemas#versioning), each schema needs an entry in `versions.json` for it to be published, although we forgot to do that in https://github.com/ably/ably-common/pull/118, so this PR adds those versions.

I've also updated the JSON schema docs to include instructions for AWS access.