### PR TITLE
Add `ably-flutter` Ably agent

### DIFF
--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -109,6 +109,12 @@
       "type": "wrapper"
     },
     {
+      "identifier": "ably-flutter",
+      "versioned": true,
+      "emitters": ["ably-flutter"],
+      "type": "wrapper"
+    },
+    {
       "identifier": "kafka-connect-ably",
       "versioned": true,
       "emitters": ["kafka-connect-ably"],


### PR DESCRIPTION
This work is a pre-requisite and accompanies the Ably agent work for Ably Flutter: https://github.com/ably/ably-flutter/issues/100.