### PR TITLE
Add Dart to agents.json

### DIFF
--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -234,7 +234,6 @@
     "cocoa.ios": "ably-cocoa/${version} iOS/0.0.0",
     "cocoa.macos": "ably-cocoa/${version} macOS/0.0.0",
     "cocoa.tvos": "ably-cocoa/${version} tvOS/0.0.0",
-    "dart": "dart/${version}",
     "dotnet": "ably-dotnet/${version}",
     "dotnet.framework": "ably-dotnet/${version} dotnet-framework/0.0.0",
     "dotnet.uwp": "ably-dotnet/${version} uwp",

--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -115,6 +115,12 @@
       "type": "wrapper"
     },
     {
+      "identifier": "dart",
+      "versioned": true,
+      "emitters": ["ably-flutter"],
+      "type": "runtime"
+    },
+    {
       "identifier": "kafka-connect-ably",
       "versioned": true,
       "emitters": ["kafka-connect-ably"],
@@ -228,6 +234,7 @@
     "cocoa.ios": "ably-cocoa/${version} iOS/0.0.0",
     "cocoa.macos": "ably-cocoa/${version} macOS/0.0.0",
     "cocoa.tvos": "ably-cocoa/${version} tvOS/0.0.0",
+    "dart": "dart/${version}",
     "dotnet": "ably-dotnet/${version}",
     "dotnet.framework": "ably-dotnet/${version} dotnet-framework/0.0.0",
     "dotnet.uwp": "ably-dotnet/${version} uwp",


### PR DESCRIPTION
I'm not sue if I got everything right, but in scope of https://github.com/ably/ably-flutter/issues/286, I wanted to add additional header with Dart runtime version to `agents`. The entire header sent by `ably-flutter` looks like this:

```
Ably-Agent: ably-java/1.2.11 dart/2.16.2 ably-flutter/1.2.13 android/31
```

So I think if should be fine with the definitions I added to `agents`, but I'm not entirely sure if configuration inside `ablyLibMappings` is correct, so additional verification would be appreciated.