### PR TITLE
Fix permissions in JSON Schema publish action

### DIFF
--- a/.github/workflows/publish-json-schemas.yml
+++ b/.github/workflows/publish-json-schemas.yml
@@ -6,6 +6,8 @@ on: workflow_dispatch
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The build needs `id-token: write` to be able to use the GitHub ID token to request AWS credentials.