### PR TITLE
Update JSON schema publish instructions

### DIFF
--- a/json-schemas/README.md
+++ b/json-schemas/README.md
@@ -20,17 +20,17 @@ publish time (see below).
 
 ## Publish
 
-Set the `SDK_S3_ACCESS_KEY_ID` and `SDK_S3_ACCESS_KEY` environment variables to
-an AWS access key and secret that has write permissions to the `schemas.ably.com`
-S3 bucket in the SDK AWS account. If you are a SuperAdmin in the SDK AWS account,
-then run the following:
+Manually run the [`publish-json-schemas.yml`](https://github.com/ably/ably-common/actions/workflows/publish-json-schemas.yml)
+GitHub Action to publish all the JSON schemas to `https://schemas.ably.com`.
+
+Alternatively, to publish locally, configure your environment with AWS
+credentials that have write permission to the `schemas.ably.com` S3 bucket
+in the SDK AWS account:
 
 ```bash
 source <(ably-env secrets print-aws --account sdk --role SuperAdmin)
-export SDK_S3_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
-export SDK_S3_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
 ```
 
-Run `npm run publish:json-schemas`.
+Then run `npm run publish:json-schemas`.
 
 See `publish.js` for more information.


### PR DESCRIPTION
We now publish JSON schemas using a GitHub Action, see https://github.com/ably/ably-common/pull/147.