### PR TITLE
Add channel lifecycle events schema

### DIFF
--- a/json-schemas/src/channel-lifecycle-events.json
+++ b/json-schemas/src/channel-lifecycle-events.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Ably Channel Lifecycle Event",
+  "type": "object",
+  "properties": {
+    "channelId": {
+      "type": "string",
+      "description": "The ID of the channel"
+    },
+    "eventName": {
+      "type": "string",
+      "description": "The name of the channel lifecycle event"
+    },
+    "region": {
+      "type": "string",
+      "description": "The region in which the event occurred"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "The ISO 8601 formatted timestamp of the time that the event occurred"
+    },
+    "eventId": {
+      "type": "string",
+      "description": "A unique identifier for the event"
+    }
+  },
+  "additionalProperties": false,
+  "required": ["channelId", "eventName", "timestamp", "eventId"]
+}

--- a/json-schemas/versions.json
+++ b/json-schemas/versions.json
@@ -2,5 +2,6 @@
   "agents": "0.0.1",
   "app-stats": "0.0.2",
   "client-events-api-requests": "0.0.1",
-  "client-events-connections": "0.0.1"
+  "client-events-connections": "0.0.1",
+  "channel-lifecycle-events": "0.0.1"
 }


### PR DESCRIPTION
This commit introduces a new schema definition for channel lifecycle
events that will be ingested into the data analytics platform.

SEE: https://ably.atlassian.net/browse/REA-1348