### PR TITLE
Add client events connection's token credentials

### DIFF
--- a/json-schemas/src/client-events-connections.json
+++ b/json-schemas/src/client-events-connections.json
@@ -76,7 +76,7 @@
       "type": "integer",
       "description": "The duration the connection was open for in milliseconds."
     },
-    "credentials": {
+    "credential": {
       "type": "object",
       "description": "The connection's token credentials.",
       "properties": {
@@ -93,7 +93,7 @@
           "description": "The credential type: either 'key', 'ablyToken', 'ablyJWT', or 'ablyJWE'."
         }
       },
-      "required": ["hasUserClaims", "type"]
+      "required": ["hasUserClaims", "keyName", "type"]
     },
     "error": {
       "type": "object",

--- a/json-schemas/src/client-events-connections.json
+++ b/json-schemas/src/client-events-connections.json
@@ -76,6 +76,25 @@
       "type": "integer",
       "description": "The duration the connection was open for in milliseconds."
     },
+    "credentials": {
+      "type": "object",
+      "description": "The connection's token credentials.",
+      "properties": {
+        "hasUserClaims": {
+          "type": "boolean",
+          "description": "Does this token contain user claims."
+        },
+        "keyName": {
+          "type": "string",
+          "description": "The token's key name."
+        },
+        "type": {
+          "type": "string",
+          "description": "The credential type: either 'key', 'ablyToken', 'ablyJWT', or 'ablyJWE'."
+        }
+      },
+      "required": ["hasUserClaims", "type"]
+    },
     "error": {
       "type": "object",
       "description": "The details of any error encountered whilst processing the connection.",


### PR DESCRIPTION
This is the ably-common changes for [#4269](https://github.com/ably/realtime/pull/4269).

This adds client events connection's token credentials information to the schema.