### PR TITLE
Fix heartbeats schema definition

### DIFF
--- a/json-schemas/src/client-events-connections.json
+++ b/json-schemas/src/client-events-connections.json
@@ -51,8 +51,9 @@
           "description": "The format used to encode protocol messages. Either 'json' or 'msgpack'."
         },
         "heartbeats": {
-          "type": "boolean",
-          "description": "The type of heartbeats to send on the connection. True for Ably protocol heartbeats, false for transport specific heartbeats."
+          "type": "string",
+          "description": "The type of heartbeats to send on the connection. True for Ably protocol heartbeats, false for transport specific heartbeats.",
+          "enum": ["true", "false"]
         },
         "v": {
           "type": "string",


### PR DESCRIPTION
The previous schema defined a boolean type for the query.heartbeats
field. However, in actuality when these events are generated the type is
actually a string with either the value "true" or "false". This is
because the value is extracted from URL query parameters and no type
conversion is done.

This fix allows the realtime tests to pass, as the ably-common submodule
has been updated as part of https://github.com/ably/realtime/pull/4268,
for https://ably.atlassian.net/browse/REA-1348.