### PR TITLE
Remove `emitters` from `agents.json`

### DIFF
--- a/json-schemas/src/agents.json
+++ b/json-schemas/src/agents.json
@@ -13,13 +13,6 @@
             "description": "The identifier (product name) as it appears in the Ably-Agent string. See RSC7d in the Ably Features spec for more information.",
             "type": "string"
           },
-          "emitters": {
-            "type": "array",
-            "description": "An array containing the names of Ably SDKs which directly emit this identifier. SDK names must match the repository name we use in GitHub (i.e. the component that appears after ably org in the URL).",
-            "items": {
-              "type": "string"
-            }
-          },
           "versioned": {
             "type": "boolean",
             "description": "If true, indicates that the identifier will have an associated version."
@@ -30,7 +23,7 @@
             "enum": ["os", "sdk", "wrapper", "runtime"]
           }
         },
-        "required": ["identifier", "emitters", "versioned", "type"]
+        "required": ["identifier", "versioned", "type"]
       }
     },
     "ablyLibMappings": {

--- a/json-schemas/versions.json
+++ b/json-schemas/versions.json
@@ -1,5 +1,5 @@
 {
-  "agents": "0.0.1",
+  "agents": "0.0.2",
   "app-stats": "0.0.2",
   "client-events-api-requests": "0.0.1",
   "client-events-connections": "0.0.1",

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -66,6 +66,48 @@ request against the `main` branch with those changes.
 Once the pull request is merged into `main`, open an internal ticket requesting that the realtime team
 follow the "Publishing Changes" steps below.
 
+### Additional Notes on Agents
+
+The following table adds more contextual detail for some agent identifiers, where:
+
+- The table does not include those where `type` is `sdk`.
+  In these cases there is always only a single emitter, where the identifier value matches the name of the SDK source code repository in the `ably` GitHub org - e.g. identifier `ably-js` is emitted by [ably-js](https://github.com/ably/ably-js).
+- The table rows are sorted alphabetically by identifier.
+- It intentionally does not include columns that repeat information that is already canonically defined in [agents.json](agents.json) (e.g. values of `versioned` and `type`).
+- The 'Emitters' column provides links to SDK source code repositories which directly emit this identifier.
+
+| Identifier | Emitters |
+| ---------- | -------- |
+| `ably-asset-tracking-android` | [ably-asset-tracking-android](https://github.com/ably/ably-asset-tracking-android) |
+| `ably-asset-tracking-swift` | [ably-asset-tracking-swift](https://github.com/ably/ably-asset-tracking-swift) |
+| `ably-flutter` | [ably-flutter](https://github.com/ably/ably-flutter) |
+| `ably-ruby-rest` | [ably-ruby](https://github.com/ably/ably-ruby) |
+| `android` | [ably-java](https://github.com/ably/ably-java), [ably-dotnet](https://github.com/ably/ably-dotnet) |
+| `browser` | [ably-js](https://github.com/ably/ably-js) |
+| `dart` | [ably-flutter](https://github.com/ably/ably-flutter) |
+| `darwin` | [ably-go](https://github.com/ably/ably-go) |
+| `dotnet-framework` | [ably-dotnet](https://github.com/ably/ably-dotnet) |
+| `dotnet-standard` | [ably-dotnet](https://github.com/ably/ably-dotnet) |
+| `go` | [ably-go](https://github.com/ably/ably-go) |
+| `iOS` | [ably-cocoa](https://github.com/ably/ably-cocoa), [ably-dotnet](https://github.com/ably/ably-dotnet) |
+| `jre` | [ably-java](https://github.com/ably/ably-java) |
+| `kafka-connect-ably` | [kafka-connect-ably](https://github.com/ably/kafka-connect-ably) |
+| `laravel` | [ably-php](https://github.com/ably/ably-php) |
+| `linux` | [ably-dotnet](https://github.com/ably/ably-dotnet), [ably-go](https://github.com/ably/ably-go) |
+| `macOS` | [ably-cocoa](https://github.com/ably/ably-cocoa), [ably-dotnet](https://github.com/ably/ably-dotnet) |
+| `nativescript` | [ably-js](https://github.com/ably/ably-js) |
+| `nodejs` | [ably-js](https://github.com/ably/ably-js) |
+| `php` | [ably-php](https://github.com/ably/ably-php) |
+| `python` | [ably-python](https://github.com/ably/ably-python) |
+| `react-native` | [ably-js](https://github.com/ably/ably-js) |
+| `ruby` | [ably-ruby](https://github.com/ably/ably-ruby) |
+| `tvOS` | [ably-cocoa](https://github.com/ably/ably-cocoa) |
+| `unity` | [ably-dotnet](https://github.com/ably/ably-dotnet) |
+| `uwp` | [ably-dotnet](https://github.com/ably/ably-dotnet) |
+| `watchOS` | [ably-cocoa](https://github.com/ably/ably-cocoa) |
+| `windows` | [ably-dotnet](https://github.com/ably/ably-dotnet), [ably-go](https://github.com/ably/ably-go) |
+| `xamarin` | [ably-dotnet](https://github.com/ably/ably-dotnet) |
+
 ### Publishing Changes
 
 #### Step 1: Public

--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -3,223 +3,186 @@
     {
       "identifier": "ably-js",
       "versioned": true,
-      "emitters": ["ably-js"],
       "type": "sdk"
     },
     {
       "identifier": "nodejs",
       "versioned": true,
-      "emitters": ["ably-js"],
       "type": "runtime"
     },
     {
       "identifier": "browser",
       "versioned": false,
-      "emitters": ["ably-js"],
       "type": "runtime"
     },
     {
       "identifier": "nativescript",
       "versioned": true,
-      "emitters": ["ably-js"],
       "type": "wrapper"
     },
     {
       "identifier": "react-native",
       "versioned": false,
-      "emitters": ["ably-js"],
       "type": "wrapper"
     },
     {
       "identifier": "ably-cocoa",
       "versioned": true,
-      "emitters": ["ably-cocoa"],
       "type": "sdk"
     },
     {
       "identifier": "iOS",
       "versioned": true,
-      "emitters": ["ably-cocoa", "ably-dotnet"],
       "type": "os"
     },
     {
       "identifier": "tvOS",
       "versioned": true,
-      "emitters": ["ably-cocoa"],
       "type": "os"
     },
     {
       "identifier": "watchOS",
       "versioned": true,
-      "emitters": ["ably-cocoa"],
       "type": "os"
     },
     {
       "identifier": "macOS",
       "versioned": true,
-      "emitters": ["ably-cocoa", "ably-dotnet"],
       "type": "os"
     },
     {
       "identifier": "darwin",
       "versioned": true,
-      "emitters": ["ably-go"],
       "type": "os"
     },
     {
       "identifier": "windows",
       "versioned": true,
-      "emitters": ["ably-dotnet", "ably-go"],
       "type": "os"
     },
     {
       "identifier": "linux",
       "versioned": true,
-      "emitters": ["ably-dotnet", "ably-go"],
       "type": "os"
     },
     {
       "identifier": "ably-java",
       "versioned": true,
-      "emitters": ["ably-java"],
       "type": "sdk"
     },
     {
       "identifier": "jre",
       "versioned": true,
-      "emitters": ["ably-java"],
       "type": "runtime"
     },
     {
       "identifier": "android",
       "versioned": true,
-      "emitters": ["ably-java", "ably-dotnet"],
       "type": "os"
     },
     {
       "identifier": "ably-asset-tracking-android",
       "versioned": true,
-      "emitters": ["ably-asset-tracking-android"],
       "type": "wrapper"
     },
     {
       "identifier": "ably-asset-tracking-swift",
       "versioned": true,
-      "emitters": ["ably-asset-tracking-swift"],
       "type": "wrapper"
     },
     {
       "identifier": "ably-flutter",
       "versioned": true,
-      "emitters": ["ably-flutter"],
       "type": "wrapper"
     },
     {
       "identifier": "dart",
       "versioned": true,
-      "emitters": ["ably-flutter"],
       "type": "runtime"
     },
     {
       "identifier": "kafka-connect-ably",
       "versioned": true,
-      "emitters": ["kafka-connect-ably"],
       "type": "wrapper"
     },
     {
       "identifier": "ably-ruby",
       "versioned": true,
-      "emitters": ["ably-ruby"],
       "type": "sdk"
     },
     {
       "identifier": "ruby",
       "versioned": true,
-      "emitters": ["ably-ruby"],
       "type": "runtime"
     },
     {
       "identifier": "ably-ruby-rest",
       "versioned": false,
-      "emitters": ["ably-ruby"],
       "type": "wrapper"
     },
     {
       "identifier": "ably-dotnet",
       "versioned": true,
-      "emitters": ["ably-dotnet"],
       "type": "sdk"
     },
     {
       "identifier": "dotnet-framework",
       "versioned": true,
-      "emitters": ["ably-dotnet"],
       "type": "runtime"
     },
     {
       "identifier": "dotnet-standard",
       "versioned": true,
-      "emitters": ["ably-dotnet"],
       "type": "runtime"
     },
     {
       "identifier": "uwp",
       "versioned": false,
-      "emitters": ["ably-dotnet"],
       "type": "runtime"
     },
     {
       "identifier": "xamarin",
       "versioned": false,
-      "emitters": ["ably-dotnet"],
       "type": "runtime"
     },
     {
       "identifier": "unity",
       "versioned": true,
-      "emitters": ["ably-dotnet"],
       "type": "runtime"
     },
     {
       "identifier": "python",
       "versioned": true,
-      "emitters": ["ably-python"],
       "type": "runtime"
     },
     {
       "identifier": "ably-python",
       "versioned": true,
-      "emitters": ["ably-python"],
       "type": "sdk"
     },
     {
       "identifier": "ably-php",
       "versioned": true,
-      "emitters": ["ably-php"],
       "type": "sdk"
     },
     {
       "identifier": "php",
       "versioned": true,
-      "emitters": ["ably-php"],
       "type": "runtime"
     },
     {
       "identifier": "laravel",
       "versioned": true,
-      "emitters": ["ably-php"],
       "type": "wrapper"
     },
     {
       "identifier": "ably-go",
       "versioned": true,
-      "emitters": ["ably-go"],
       "type": "sdk"
     },
     {
       "identifier": "go",
       "versioned": true,
-      "emitters": ["ably-go"],
       "type": "runtime"
     }
   ],


### PR DESCRIPTION
In response to @lmars observation: https://github.com/ably/ably-common/pull/170#issuecomment-1298434216

The change presented in this pull request is intended to become the new target for the aforementioned pull request, removing the need to specify `emitters` in the JSON, and removing the confusion that this field's existence was creating.

See also [this Slack thread (internal)](https://ably-real-time.slack.com/archives/C01LHF5BV7D/p1667149285594959).

Once this pull request has landed to the `main` (default) branch then [JSON Schemas should be published](https://github.com/ably/ably-common/tree/main/json-schemas#publish).