### PR TITLE
agents: Add ably-go to ablyLibMappings

### DIFF
--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -202,6 +202,7 @@
     "js-ns": "ably-js/${version} nativescript",
     "js-rn": "ably-js/${version} react-native",
     "go": "ably-go/${version}",
+    "ably-go": "ably-go/${version}",
     "android": "ably-java/${version} android/0.0.0",
     "java": "ably-java/${version}",
     "cocoa.ios": "ably-cocoa/${version} iOS/0.0.0",


### PR DESCRIPTION
To track old ably-go versions which set `X-Ably-Lib` to `ably-go-<version>` rather than `go-<version>`, which was changed in Nov 2020: https://github.com/ably/ably-go/pull/210

Fixes #179.