### PR TITLE
app-stats.json: add inProgress; add all possibilities for unit; tweak description of intervalId

### DIFF
--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -9,16 +9,20 @@
     },
     "intervalId": {
       "type": "string",
-      "description": "time period for statistics in date-time format yyyy-mm-dd:hh:mm:ss"
+      "description": "Start time for this stats entry. Format is yyyy-mm-dd:hh:mm for unit=minute, and yyyy-mm-dd:hh for unit=hour,day,month"
     },
     "unit": {
       "type": "string",
-      "description": "Unit of time for these statistics from the intervalId forwards.",
-      "pattern": "^minute$"
+      "description": "Unit of time that this stats entry covers (partially in the case of an in-progress entry)",
+      "enum": ["minute", "hour", "day", "month"]
     },
     "schema": {
       "type": "string",
       "description": "URI to this schema."
+    },
+    "inProgress": {
+      "type": "string",
+      "description": "for entries that are still in progress, such as the current month: the last sub-interval included in this entry (in format yyyy-mm-dd:hh:mm:ss), else undefined"
     },
     "entries": {
       "type": "object",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -22,7 +22,7 @@
     },
     "inProgress": {
       "type": "string",
-      "description": "for entries that are still in progress, such as the current month: the last sub-interval included in this entry (in format yyyy-mm-dd:hh:mm:ss), else undefined"
+      "description": "For entries that are still in progress, such as the current month: the last sub-interval included in this entry (in format yyyy-mm-dd:hh:mm:ss), else undefined"
     },
     "entries": {
       "type": "object",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -13,7 +13,7 @@
     },
     "unit": {
       "type": "string",
-      "description": "Unit of time that this stats entry covers (partially in the case of an in-progress entry)",
+      "description": "Unit of time that this stats entry covers (partially, in the case of an in-progress entry)",
       "enum": ["minute", "hour", "day", "month"]
     },
     "schema": {


### PR DESCRIPTION
Bit of yakshaving on adding v3 stats to the rest api, my new test failed for schema validation issues, this fixes those and improves the descriptions a bit