### PR TITLE
[MMB-292] Remove error code 101005

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -58,7 +58,6 @@ Codes for Asset Tracking are maintained externally.
 | 101002 | Lock request exists |
 | 101003 | Lock is locked |
 | 101004 | Lock invalidated |
-| 101005 | Lock released |
 
 ## Agents
 

--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -173,6 +173,5 @@
   "101001": "must enter a space to perform this operation",
   "101002": "lock request already exists",
   "101003": "lock is currently locked",
-  "101004": "lock was invalidated by a concurrent lock request which now holds the lock",
-  "101005": "lock was released"
+  "101004": "lock was invalidated by a concurrent lock request which now holds the lock"
 }

--- a/protocol/errorsHelp.json
+++ b/protocol/errorsHelp.json
@@ -72,6 +72,5 @@
   "101001": "https://faqs.ably.com/error-code-101001",
   "101002": "https://faqs.ably.com/error-code-101002",
   "101003": "https://faqs.ably.com/error-code-101003",
-  "101004": "https://faqs.ably.com/error-code-101004",
-  "101004": "https://faqs.ably.com/error-code-101005"
+  "101004": "https://faqs.ably.com/error-code-101004"
 }


### PR DESCRIPTION
Spaces error code `101005` was removed in https://github.com/ably/spaces/pull/164. This reflects the change by removing it from the listed errors, and also fixes an issue where `101004` was directing people to two different FAQs.