### PR TITLE
protocol: add models agent

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -115,6 +115,7 @@ The following table adds more contextual detail for some agent identifiers, wher
 | `spaces` | [spaces](https://github.com/ably/spaces) |
 | `spaces-default-client` | [spaces](https://github.com/ably/spaces) |
 | `spaces-custom-client` | [spaces](https://github.com/ably/spaces) |
+| `models` | [models](https://github.com/ably-labs/models) |
 | `tvOS` | [ably-cocoa](https://github.com/ably/ably-cocoa) |
 | `unity` | [ably-dotnet](https://github.com/ably/ably-dotnet) |
 | `uwp` | [ably-dotnet](https://github.com/ably/ably-dotnet) |

--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -336,6 +336,11 @@
       "type": "runtime"
     },
     {
+      "identifier": "models",
+      "versioned": true,
+      "type": "wrapper"
+    },
+    {
       "identifier": "ably-control-go",
       "versioned": true,
       "type": "sdk"


### PR DESCRIPTION
This commit adds the Models SDK agent to facilitate usage tracking.

See https://github.com/ably-labs/models/pull/93 for the implementation.