### PR TITLE
Add missing epochs entry in versions.json

### DIFF
--- a/json-schemas/versions.json
+++ b/json-schemas/versions.json
@@ -5,5 +5,6 @@
   "client-events-api-requests": "0.0.1",
   "client-events-connections": "0.0.1",
   "channel-lifecycle": "0.0.1",
-  "attachments": "0.0.1"
+  "attachments": "0.0.1",
+  "epochs": "0.0.1"
 }


### PR DESCRIPTION
Necessary because the [publish workflow](https://github.com/ably/ably-common/actions/workflows/publish-json-schemas.yml) is currently failing