### PR TITLE
docs: add ably-chat-js to README

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -97,6 +97,7 @@ The following table adds more contextual detail for some agent identifiers, wher
 | `ably-ruby-rest` | [ably-ruby](https://github.com/ably/ably-ruby) |
 | `android` | [ably-java](https://github.com/ably/ably-java), [ably-dotnet](https://github.com/ably/ably-dotnet) |
 | `browser` | [ably-js](https://github.com/ably/ably-js) |
+| `chat-js` | [ably-chat-js](https://github.com/ably/ably-chat-js) |
 | `dart` | [ably-flutter](https://github.com/ably/ably-flutter) |
 | `darwin` | [ably-go](https://github.com/ably/ably-go) |
 | `dotnet-framework` | [ably-dotnet](https://github.com/ably/ably-dotnet) |


### PR DESCRIPTION
[CHA-275]

Adds ably-chat-js to the README list of agents.

[CHA-275]: https://ably.atlassian.net/browse/CHA-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ