### PR TITLE
App account stats schemas: add lots of missing entries, fix 'processed' entries, update terminology

### DIFF
--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -42,7 +42,7 @@
         "messages.all.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.all.refused": {
           "type": "number",
@@ -62,12 +62,12 @@
         "messages.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.refused": {
           "type": "number",
@@ -92,7 +92,7 @@
         "messages.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.refused": {
           "type": "number",
@@ -117,7 +117,7 @@
         "messages.inbound.realtime.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound realtime messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.realtime.all.refused": {
           "type": "number",
@@ -142,7 +142,7 @@
         "messages.inbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as ejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as ejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.inbound.realtime.messages.refused": {
           "type": "number",
@@ -167,7 +167,7 @@
         "messages.inbound.realtime.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound realtime presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.realtime.presence.refused": {
           "type": "number",
@@ -192,7 +192,7 @@
         "messages.inbound.rest.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.rest.all.refused": {
           "type": "number",
@@ -232,7 +232,7 @@
         "messages.inbound.rest.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound REST presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound REST presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.rest.presence.refused": {
           "type": "number",
@@ -257,7 +257,7 @@
         "messages.inbound.all.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.all.refused": {
           "type": "number",
@@ -282,7 +282,7 @@
         "messages.inbound.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.presence.count": {
           "type": "number",
@@ -302,7 +302,7 @@
         "messages.inbound.all.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.presence.refused": {
           "type": "number",
@@ -352,7 +352,7 @@
         "messages.outbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of outbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.outbound.realtime.messages.refused": {
           "type": "number",
@@ -377,7 +377,7 @@
         "messages.outbound.realtime.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of outbound realtime presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.outbound.realtime.presence.refused": {
           "type": "number",
@@ -447,7 +447,7 @@
         "messages.outbound.webhook.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound Webhook messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.all.refused": {
           "type": "number",
@@ -472,7 +472,7 @@
         "messages.outbound.webhook.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound Webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.messages.refused": {
           "type": "number",
@@ -497,7 +497,7 @@
         "messages.outbound.webhook.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound Webhook presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.presence.refused": {
           "type": "number",
@@ -747,7 +747,7 @@
         "messages.outbound.push.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+          "description": "Total number of Push messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
         },
         "messages.outbound.push.all.refused": {
           "type": "number",
@@ -772,7 +772,7 @@
         "messages.outbound.push.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+          "description": "Total number of Push messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
         },
         "messages.outbound.push.messages.refused": {
           "type": "number",
@@ -797,7 +797,7 @@
         "messages.outbound.push.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+          "description": "Total number of Push presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
         },
         "messages.outbound.push.presence.refused": {
           "type": "number",
@@ -822,7 +822,7 @@
         "messages.outbound.all.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of outbound messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
         },
         "messages.outbound.all.all.refused": {
           "type": "number",
@@ -847,7 +847,7 @@
         "messages.outbound.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of outbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
         },
         "messages.outbound.all.messages.refused": {
           "type": "number",
@@ -872,7 +872,7 @@
         "messages.outbound.all.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of outbound presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
         },
         "messages.outbound.all.presence.refused": {
           "type": "number",

--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -507,152 +507,152 @@
         "messages.outbound.sharedQueue.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue message count (sent from the Ably service to a Reactor Queue)."
+          "description": "Total Ably Queue message count (sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue message size (sent from the Ably service to a Reactor Queue)."
+          "description": "Total Ably Queue message size (sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Ably Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue messages that failed (which were rejected by RabbitMQ for some reason)"
+          "description": "Total number of Ably Queue messages that failed (which were rejected by RabbitMQ for some reason)"
         },
         "messages.outbound.sharedQueue.all.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Ably Queue messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue message count (sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total Ably Queue message count (sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue message size (sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total Ably Queue message size (sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total uncompressed Ably Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue messages excluding presence messages that failed (which were rejected by RabbitMQ for some reason)"
+          "description": "Total number of Ably Queue messages excluding presence messages that failed (which were rejected by RabbitMQ for some reason)"
         },
         "messages.outbound.sharedQueue.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Ably Queue messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue presence message count (sent from the Ably service to a Reactor Queue)."
+          "description": "Total Ably Queue presence message count (sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.presence.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue presence message size (sent from the Ably service to a Reactor Queue)."
+          "description": "Total Ably Queue presence message size (sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Ably Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue presence messages that failed (which were rejected by RabbitMQ for some reason)"
+          "description": "Total number of Ably Queue presence messages that failed (which were rejected by RabbitMQ for some reason)"
         },
         "messages.outbound.sharedQueue.presence.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Ably Queue presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose message count (sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total Firehose message count (sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose message size (sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total Firehose message size (sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose messages that failed (which were rejected by the external integration target for some reason)"
+          "description": "Total number of Firehose messages that failed (which were rejected by the external integration target for some reason)"
         },
         "messages.outbound.externalQueue.all.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Firehose messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose message count (sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total Firehose message count (sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose message size (sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total Firehose message size (sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total uncompressed Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose messages excluding presence messages that failed (which were rejected by the external integration target for some reason)"
+          "description": "Total number of Firehose messages excluding presence messages that failed (which were rejected by the external integration target for some reason)"
         },
         "messages.outbound.externalQueue.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Firehose messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose presence message count (sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total Firehose presence message count (sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.presence.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose presence message size (sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total Firehose presence message size (sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose presence messages that failed (which were rejected by the external integration target for some reason)"
+          "description": "Total number of Firehose presence messages that failed (which were rejected by the external integration target for some reason)"
         },
         "messages.outbound.externalQueue.presence.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Firehose presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.all.count": {
           "type": "number",
@@ -1158,7 +1158,7 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of direct push publishes (that is, notifications triggered by a request to /push/publish, not a channel message with a push payload)."
-        }
+        },
         "peakRates.messages": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -1187,27 +1187,27 @@
         "peakRates.reactor.httpEvent": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Peak rate of reactor http events."
+          "description": "Peak rate of events sent to an HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "peakRates.reactor.amqp": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Peak rate of reactor amqp rule invocations."
+          "description": "Peak rate of events sent to an Ably Queue using an integration rule."
         },
         "peakRates.reactor.externalQueue": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Peak rate of reactor externalQueue rule invocations."
+          "description": "Peak rate of events sent to an external endpoint using a Firehose integration rule."
         },
         "peakRates.reactor.webhook": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Peak rate of reactor webhook invocations."
+          "description": "Peak rate of events sent to webhook configured through an integration rule."
         },
         "peakRates.pushRequests": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Peak rate of pushRequests."
+          "description": "Peak rate of push api requests."
         }
       }
     }

--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -27,17 +27,27 @@
         "messages.all.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total message count."
+          "description": "Total number of successful messages, summed over all message types and transports."
         },
         "messages.all.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total message size."
+          "description": "Total message size of all messages successfully sent, summed over all message types and transports."
         },
         "messages.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas)."
+          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas)."
+        },
+        "messages.all.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.all.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.all.messages.count": {
           "type": "number",
@@ -52,7 +62,17 @@
         "messages.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas), excluding presence messages."
+          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.all.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.all.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.all.presence.count": {
           "type": "number",
@@ -67,7 +87,17 @@
         "messages.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas)."
+          "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas)."
+        },
+        "messages.all.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.all.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of presence messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.realtime.all.count": {
           "type": "number",
@@ -82,7 +112,17 @@
         "messages.inbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.realtime.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.realtime.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.realtime.messages.count": {
           "type": "number",
@@ -97,7 +137,17 @@
         "messages.inbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+        },
+        "messages.inbound.realtime.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as ejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.inbound.realtime.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.realtime.presence.count": {
           "type": "number",
@@ -112,7 +162,17 @@
         "messages.inbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.realtime.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.realtime.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.rest.all.count": {
           "type": "number",
@@ -127,7 +187,17 @@
         "messages.inbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.rest.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.rest.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.rest.messages.count": {
           "type": "number",
@@ -142,7 +212,7 @@
         "messages.inbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
         },
         "messages.inbound.rest.presence.count": {
           "type": "number",
@@ -157,7 +227,17 @@
         "messages.inbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.rest.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.rest.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.all.all.count": {
           "type": "number",
@@ -172,7 +252,17 @@
         "messages.inbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.all.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.all.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.all.messages.count": {
           "type": "number",
@@ -187,7 +277,12 @@
         "messages.inbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+        },
+        "messages.inbound.all.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.presence.count": {
           "type": "number",
@@ -202,7 +297,17 @@
         "messages.inbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.all.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.all.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.outbound.realtime.all.count": {
           "type": "number",
@@ -217,7 +322,17 @@
         "messages.outbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.realtime.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime messages that failed (which did not succeed for some reason other than Ably rejecting it, such as being rejected by an external integration target)"
+        },
+        "messages.outbound.realtime.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.realtime.messages.count": {
           "type": "number",
@@ -232,7 +347,17 @@
         "messages.outbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+        },
+        "messages.outbound.realtime.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.outbound.realtime.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime messages excluding presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.realtime.presence.count": {
           "type": "number",
@@ -247,7 +372,17 @@
         "messages.outbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.realtime.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.outbound.realtime.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.rest.all.count": {
           "type": "number",
@@ -262,7 +397,7 @@
         "messages.outbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.rest.messages.count": {
           "type": "number",
@@ -277,7 +412,7 @@
         "messages.outbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",
@@ -292,52 +427,82 @@
         "messages.outbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.webhook.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook message count (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound Webhook message count (sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook message size (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound Webhook message size (sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+        },
+        "messages.outbound.webhook.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+        },
+        "messages.outbound.webhook.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook message count (sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total outbound Webhook message count (sent from the Ably service to clients using Webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook message size (sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total outbound Webhook message size (sent from the Ably service to clients using Webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
+        },
+        "messages.outbound.webhook.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+        },
+        "messages.outbound.webhook.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook messages excluding presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook presence message count (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound Webhook presence message count (sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.presence.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook presence message size (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound Webhook presence message size (sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+        },
+        "messages.outbound.webhook.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+        },
+        "messages.outbound.webhook.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.sharedQueue.all.count": {
           "type": "number",
@@ -352,7 +517,17 @@
         "messages.outbound.sharedQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
+        },
+        "messages.outbound.sharedQueue.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue messages that failed (which were rejected by RabbitMQ for some reason)"
+        },
+        "messages.outbound.sharedQueue.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.messages.count": {
           "type": "number",
@@ -367,7 +542,17 @@
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
+        },
+        "messages.outbound.sharedQueue.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue messages excluding presence messages that failed (which were rejected by RabbitMQ for some reason)"
+        },
+        "messages.outbound.sharedQueue.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.presence.count": {
           "type": "number",
@@ -382,7 +567,17 @@
         "messages.outbound.sharedQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
+        },
+        "messages.outbound.sharedQueue.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue presence messages that failed (which were rejected by RabbitMQ for some reason)"
+        },
+        "messages.outbound.sharedQueue.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.all.count": {
           "type": "number",
@@ -397,7 +592,17 @@
         "messages.outbound.externalQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+        },
+        "messages.outbound.externalQueue.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose messages that failed (which were rejected by the external integration target for some reason)"
+        },
+        "messages.outbound.externalQueue.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.messages.count": {
           "type": "number",
@@ -412,7 +617,17 @@
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+        },
+        "messages.outbound.externalQueue.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose messages excluding presence messages that failed (which were rejected by the external integration target for some reason)"
+        },
+        "messages.outbound.externalQueue.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.presence.count": {
           "type": "number",
@@ -427,7 +642,17 @@
         "messages.outbound.externalQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+        },
+        "messages.outbound.externalQueue.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose presence messages that failed (which were rejected by the external integration target for some reason)"
+        },
+        "messages.outbound.externalQueue.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.all.count": {
           "type": "number",
@@ -442,7 +667,17 @@
         "messages.outbound.httpEvent.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+        },
+        "messages.outbound.httpEvent.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages sent by a HTTP trigger that failed (which were rejected by the external endpoint for some reason)"
+        },
+        "messages.outbound.httpEvent.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages sent by a HTTP trigger that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.messages.count": {
           "type": "number",
@@ -457,7 +692,17 @@
         "messages.outbound.httpEvent.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+        },
+        "messages.outbound.httpEvent.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages sent by a HTTP trigger excluding presence messages that failed (which were rejected by the external endpoint for some reason)"
+        },
+        "messages.outbound.httpEvent.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages sent by a HTTP trigger excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.presence.count": {
           "type": "number",
@@ -472,7 +717,17 @@
         "messages.outbound.httpEvent.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+        },
+        "messages.outbound.httpEvent.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of presence messages sent by a HTTP trigger that failed (which were rejected by the external endpoint for some reason)"
+        },
+        "messages.outbound.httpEvent.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of presence messages sent by a HTTP trigger that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.push.all.count": {
           "type": "number",
@@ -487,7 +742,17 @@
         "messages.outbound.push.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+        },
+        "messages.outbound.push.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+        },
+        "messages.outbound.push.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push messages that were refused by Ably (eg due to a rate limit)"
         },
         "messages.outbound.push.messages.count": {
           "type": "number",
@@ -502,7 +767,17 @@
         "messages.outbound.push.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+        },
+        "messages.outbound.push.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+        },
+        "messages.outbound.push.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push messages excluding presence messages that were refused by Ably (eg due to a rate limit)"
         },
         "messages.outbound.push.presence.count": {
           "type": "number",
@@ -517,7 +792,17 @@
         "messages.outbound.push.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+        },
+        "messages.outbound.push.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+        },
+        "messages.outbound.push.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push presence messages that were refused by Ably (eg due to a rate limit)"
         },
         "messages.outbound.all.all.count": {
           "type": "number",
@@ -532,7 +817,17 @@
         "messages.outbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.all.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.outbound.all.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.all.messages.count": {
           "type": "number",
@@ -547,7 +842,17 @@
         "messages.outbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+        },
+        "messages.outbound.all.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.outbound.all.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound messages excluding presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.all.presence.count": {
           "type": "number",
@@ -562,7 +867,17 @@
         "messages.outbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.all.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.outbound.all.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.persisted.all.count": {
           "type": "number",
@@ -577,7 +892,7 @@
         "messages.persisted.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
         },
         "messages.persisted.messages.count": {
           "type": "number",
@@ -592,7 +907,7 @@
         "messages.persisted.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas) based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules, excluding presence messages."
         },
         "messages.persisted.presence.count": {
           "type": "number",
@@ -607,7 +922,7 @@
         "messages.persisted.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
         },
         "messages.processed.all.count": {
           "type": "number",
@@ -622,7 +937,7 @@
         "messages.processed.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
         },
         "messages.processed.messages.count": {
           "type": "number",
@@ -637,7 +952,7 @@
         "messages.processed.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas) based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules, excluding presence messages."
         },
         "messages.processed.presence.count": {
           "type": "number",
@@ -652,7 +967,7 @@
         "messages.processed.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed presence message size (excluding any compression, e.g. delta compression: https://ably.com/documentation/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed processed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
         },
         "connections.all.peak": {
           "type": "number",
@@ -677,7 +992,7 @@
         "connections.all.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of connections refused."
+          "description": "Total number of connections refused, eg for breaching the connection creation rate limit."
         },
         "channels.peak": {
           "type": "number",
@@ -702,7 +1017,7 @@
         "channels.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of channel attach requests that failed because of permissions."
+          "description": "Total number of channel creation rejected for breaching the channel creation rate limit."
         },
         "apiRequests.all.succeeded": {
           "type": "number",
@@ -873,7 +1188,7 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of direct push publishes (that is, notifications triggered by a request to /push/publish, not a channel message with a push payload)."
-        },
+        }
         "peakRates.messages": {
           "type": "number",
           "inclusiveMinimum": 0,

--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -924,50 +924,20 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
-        "messages.processed.all.count": {
+        "messages.processed.delta.xdelta.succeeded": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total processed message count based on configured channel rules."
+          "description": "Total number of message deltas successfully generated (using xdelta, currently the only supported codec), see https://ably.com/docs/channels/options/deltas."
         },
-        "messages.processed.all.data": {
+        "messages.processed.delta.xdelta.skipped": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total processed message size based on configured channel rules."
+          "description": "Total number of messages on channels where delta generation was enabled but where we skipped delta generation, eg because the payload was too small to make it worthwhile, see https://ably.com/docs/channels/options/deltas."
         },
-        "messages.processed.all.uncompressedData": {
+        "messages.processed.delta.xdelta.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
-        },
-        "messages.processed.messages.count": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total processed message count based on configured channel rules, excluding presence messages."
-        },
-        "messages.processed.messages.data": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total processed message size based on configured channel rules, excluding presence messages."
-        },
-        "messages.processed.messages.uncompressedData": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules, excluding presence messages."
-        },
-        "messages.processed.presence.count": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total processed presence message count based on configured channel rules."
-        },
-        "messages.processed.presence.data": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total processed presence message size based on configured channel rules."
-        },
-        "messages.processed.presence.uncompressedData": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
+          "description": "Total number of messages on channels where delta generation was attempted but where a delta was not successfully generated, so we just broadcast the original, see https://ably.com/docs/channels/options/deltas."
         },
         "connections.all.peak": {
           "type": "number",

--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -37,7 +37,7 @@
         "messages.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas)."
+          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas)."
         },
         "messages.all.all.failed": {
           "type": "number",
@@ -87,7 +87,7 @@
         "messages.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas)."
+          "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas)."
         },
         "messages.all.messages.failed": {
           "type": "number",
@@ -112,7 +112,7 @@
         "messages.inbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.realtime.all.failed": {
           "type": "number",
@@ -137,7 +137,7 @@
         "messages.inbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
         },
         "messages.inbound.realtime.messages.failed": {
           "type": "number",
@@ -162,7 +162,7 @@
         "messages.inbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.realtime.presence.failed": {
           "type": "number",
@@ -187,7 +187,7 @@
         "messages.inbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.rest.all.failed": {
           "type": "number",
@@ -212,7 +212,7 @@
         "messages.inbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
         },
         "messages.inbound.rest.presence.count": {
           "type": "number",
@@ -227,7 +227,7 @@
         "messages.inbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.rest.presence.failed": {
           "type": "number",
@@ -252,7 +252,7 @@
         "messages.inbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.all.all.failed": {
           "type": "number",
@@ -277,7 +277,7 @@
         "messages.inbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
         },
         "messages.inbound.all.messages.failed": {
           "type": "number",
@@ -297,7 +297,7 @@
         "messages.inbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.all.presence.failed": {
           "type": "number",
@@ -322,7 +322,7 @@
         "messages.outbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.realtime.all.failed": {
           "type": "number",
@@ -347,7 +347,7 @@
         "messages.outbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.realtime.messages.failed": {
           "type": "number",
@@ -372,7 +372,7 @@
         "messages.outbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.realtime.presence.failed": {
           "type": "number",
@@ -397,7 +397,7 @@
         "messages.outbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.rest.messages.count": {
           "type": "number",
@@ -412,7 +412,7 @@
         "messages.outbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",
@@ -427,7 +427,7 @@
         "messages.outbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.webhook.all.count": {
           "type": "number",
@@ -442,7 +442,7 @@
         "messages.outbound.webhook.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.all.failed": {
           "type": "number",
@@ -467,7 +467,7 @@
         "messages.outbound.webhook.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.failed": {
           "type": "number",
@@ -492,7 +492,7 @@
         "messages.outbound.webhook.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.presence.failed": {
           "type": "number",
@@ -517,7 +517,7 @@
         "messages.outbound.sharedQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue)."
         },
         "messages.outbound.sharedQueue.all.failed": {
           "type": "number",
@@ -542,7 +542,7 @@
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.failed": {
           "type": "number",
@@ -567,7 +567,7 @@
         "messages.outbound.sharedQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue)."
         },
         "messages.outbound.sharedQueue.presence.failed": {
           "type": "number",
@@ -592,7 +592,7 @@
         "messages.outbound.externalQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose)."
         },
         "messages.outbound.externalQueue.all.failed": {
           "type": "number",
@@ -617,7 +617,7 @@
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.failed": {
           "type": "number",
@@ -642,7 +642,7 @@
         "messages.outbound.externalQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose)."
         },
         "messages.outbound.externalQueue.presence.failed": {
           "type": "number",
@@ -667,7 +667,7 @@
         "messages.outbound.httpEvent.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "messages.outbound.httpEvent.all.failed": {
           "type": "number",
@@ -692,7 +692,7 @@
         "messages.outbound.httpEvent.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
         },
         "messages.outbound.httpEvent.messages.failed": {
           "type": "number",
@@ -717,7 +717,7 @@
         "messages.outbound.httpEvent.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "messages.outbound.httpEvent.presence.failed": {
           "type": "number",
@@ -742,7 +742,7 @@
         "messages.outbound.push.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
         },
         "messages.outbound.push.all.failed": {
           "type": "number",
@@ -767,7 +767,7 @@
         "messages.outbound.push.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
         },
         "messages.outbound.push.messages.failed": {
           "type": "number",
@@ -792,7 +792,7 @@
         "messages.outbound.push.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
         },
         "messages.outbound.push.presence.failed": {
           "type": "number",
@@ -817,7 +817,7 @@
         "messages.outbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.all.all.failed": {
           "type": "number",
@@ -842,7 +842,7 @@
         "messages.outbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.all.messages.failed": {
           "type": "number",
@@ -867,7 +867,7 @@
         "messages.outbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.all.presence.failed": {
           "type": "number",
@@ -892,7 +892,7 @@
         "messages.persisted.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
         "messages.persisted.messages.count": {
           "type": "number",
@@ -907,7 +907,7 @@
         "messages.persisted.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules, excluding presence messages."
         },
         "messages.persisted.presence.count": {
           "type": "number",
@@ -922,7 +922,7 @@
         "messages.persisted.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
         "messages.processed.all.count": {
           "type": "number",
@@ -937,7 +937,7 @@
         "messages.processed.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
         "messages.processed.messages.count": {
           "type": "number",
@@ -952,7 +952,7 @@
         "messages.processed.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules, excluding presence messages."
         },
         "messages.processed.presence.count": {
           "type": "number",
@@ -967,7 +967,7 @@
         "messages.processed.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed processed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
         "connections.all.peak": {
           "type": "number",

--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -27,7 +27,7 @@
         "messages.all.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of successful messages, summed over all message types and transports."
+          "description": "Total number of successfully-sent messages, summed over all message types and transports."
         },
         "messages.all.all.data": {
           "type": "number",
@@ -37,7 +37,7 @@
         "messages.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas)."
+          "description": "Total uncompressed message size, excluding delta compression https://ably.com/docs/channels/options/deltas."
         },
         "messages.all.all.failed": {
           "type": "number",
@@ -87,7 +87,7 @@
         "messages.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas)."
+          "description": "Total uncompressed presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas."
         },
         "messages.all.messages.failed": {
           "type": "number",
@@ -112,7 +112,7 @@
         "messages.inbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.realtime.all.failed": {
           "type": "number",
@@ -137,12 +137,12 @@
         "messages.inbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
         },
         "messages.inbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as ejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.inbound.realtime.messages.refused": {
           "type": "number",
@@ -162,7 +162,7 @@
         "messages.inbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.realtime.presence.failed": {
           "type": "number",
@@ -187,7 +187,7 @@
         "messages.inbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.rest.all.failed": {
           "type": "number",
@@ -212,7 +212,7 @@
         "messages.inbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
         },
         "messages.inbound.rest.presence.count": {
           "type": "number",
@@ -227,7 +227,7 @@
         "messages.inbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.rest.presence.failed": {
           "type": "number",
@@ -252,7 +252,7 @@
         "messages.inbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.all.all.failed": {
           "type": "number",
@@ -277,7 +277,7 @@
         "messages.inbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
         },
         "messages.inbound.all.messages.failed": {
           "type": "number",
@@ -297,7 +297,7 @@
         "messages.inbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.all.presence.failed": {
           "type": "number",
@@ -322,7 +322,7 @@
         "messages.outbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.realtime.all.failed": {
           "type": "number",
@@ -347,7 +347,7 @@
         "messages.outbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.realtime.messages.failed": {
           "type": "number",
@@ -372,7 +372,7 @@
         "messages.outbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.realtime.presence.failed": {
           "type": "number",
@@ -397,7 +397,7 @@
         "messages.outbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.rest.messages.count": {
           "type": "number",
@@ -412,7 +412,7 @@
         "messages.outbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",
@@ -427,82 +427,82 @@
         "messages.outbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.webhook.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook message count (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound webhook message count (sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook message size (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound webhook message size (sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound webhook message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound webhook messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.all.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound webhook messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook message count (sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total outbound webhook message count (sent from the Ably service to clients using webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook message size (sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total outbound webhook message size (sent from the Ably service to clients using webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total uncompressed outbound webhook message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound webhook messages excluding presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook presence message count (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound webhook presence message count (sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.presence.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook presence message size (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound webhook presence message size (sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound webhook presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound webhook presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.presence.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound webhook presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.sharedQueue.all.count": {
           "type": "number",
@@ -517,7 +517,7 @@
         "messages.outbound.sharedQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Ably Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
+          "description": "Total uncompressed Ably Queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.all.failed": {
           "type": "number",
@@ -542,7 +542,7 @@
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Ably Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
+          "description": "Total uncompressed Ably Queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.failed": {
           "type": "number",
@@ -567,7 +567,7 @@
         "messages.outbound.sharedQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Ably Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
+          "description": "Total uncompressed Ably Queue presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.presence.failed": {
           "type": "number",
@@ -592,7 +592,7 @@
         "messages.outbound.externalQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
+          "description": "Total uncompressed Firehose message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.all.failed": {
           "type": "number",
@@ -617,7 +617,7 @@
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
+          "description": "Total uncompressed Firehose message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.failed": {
           "type": "number",
@@ -642,7 +642,7 @@
         "messages.outbound.externalQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
+          "description": "Total uncompressed Firehose presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.presence.failed": {
           "type": "number",
@@ -667,7 +667,7 @@
         "messages.outbound.httpEvent.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "messages.outbound.httpEvent.all.failed": {
           "type": "number",
@@ -692,7 +692,7 @@
         "messages.outbound.httpEvent.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
         },
         "messages.outbound.httpEvent.messages.failed": {
           "type": "number",
@@ -717,7 +717,7 @@
         "messages.outbound.httpEvent.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of presence messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "messages.outbound.httpEvent.presence.failed": {
           "type": "number",
@@ -742,7 +742,7 @@
         "messages.outbound.push.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
         },
         "messages.outbound.push.all.failed": {
           "type": "number",
@@ -767,7 +767,7 @@
         "messages.outbound.push.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total uncompressed Push message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
         },
         "messages.outbound.push.messages.failed": {
           "type": "number",
@@ -792,7 +792,7 @@
         "messages.outbound.push.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
         },
         "messages.outbound.push.presence.failed": {
           "type": "number",
@@ -817,7 +817,7 @@
         "messages.outbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.all.all.failed": {
           "type": "number",
@@ -842,7 +842,7 @@
         "messages.outbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.all.messages.failed": {
           "type": "number",
@@ -867,7 +867,7 @@
         "messages.outbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.all.presence.failed": {
           "type": "number",
@@ -892,7 +892,7 @@
         "messages.persisted.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules."
         },
         "messages.persisted.messages.count": {
           "type": "number",
@@ -907,7 +907,7 @@
         "messages.persisted.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed persisted message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules, excluding presence messages."
         },
         "messages.persisted.presence.count": {
           "type": "number",
@@ -922,7 +922,7 @@
         "messages.persisted.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules."
         },
         "messages.processed.delta.xdelta.succeeded": {
           "type": "number",
@@ -932,12 +932,12 @@
         "messages.processed.delta.xdelta.skipped": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages on channels where delta generation was enabled but where we skipped delta generation, eg because the payload was too small to make it worthwhile, see https://ably.com/docs/channels/options/deltas."
+          "description": "Total number of messages on channels where delta generation was enabled but where Ably skipped delta generation, eg because the payload was too small to make it worthwhile, see https://ably.com/docs/channels/options/deltas."
         },
         "messages.processed.delta.xdelta.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages on channels where delta generation was attempted but where a delta was not successfully generated, so we just broadcast the original, see https://ably.com/docs/channels/options/deltas."
+          "description": "Total number of messages on channels where delta generation was attempted but where a delta was not successfully generated, so Ably just broadcasted the original, see https://ably.com/docs/channels/options/deltas."
         },
         "connections.all.peak": {
           "type": "number",
@@ -1207,7 +1207,7 @@
         "peakRates.pushRequests": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Peak rate of push api requests."
+          "description": "Peak rate of push API requests."
         }
       }
     }

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -31,17 +31,27 @@
         "messages.all.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total message count."
+          "description": "Total number of successful messages, summed over all message types and transports."
         },
         "messages.all.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total message size."
+          "description": "Total message size of all messages successfully sent, summed over all message types and transports."
         },
         "messages.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas)."
+          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas)."
+        },
+        "messages.all.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.all.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.all.messages.count": {
           "type": "number",
@@ -56,7 +66,17 @@
         "messages.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas), excluding presence messages."
+          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.all.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.all.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.all.presence.count": {
           "type": "number",
@@ -73,6 +93,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas)."
         },
+        "messages.all.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.all.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of presence messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
         "messages.inbound.realtime.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -87,6 +117,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.realtime.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.realtime.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.realtime.messages.count": {
           "type": "number",
@@ -103,6 +143,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
         },
+        "messages.inbound.realtime.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as ejected by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.inbound.realtime.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
         "messages.inbound.realtime.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -118,6 +168,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
         },
+        "messages.inbound.realtime.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.realtime.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
         "messages.inbound.rest.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -132,6 +192,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.rest.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.rest.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.rest.messages.count": {
           "type": "number",
@@ -163,6 +233,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
         },
+        "messages.inbound.rest.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.rest.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
         "messages.inbound.all.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -177,6 +257,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.all.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.all.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.all.messages.count": {
           "type": "number",
@@ -193,6 +283,11 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
         },
+        "messages.inbound.all.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
         "messages.inbound.all.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -207,6 +302,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+        },
+        "messages.inbound.all.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.all.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.outbound.realtime.all.count": {
           "type": "number",
@@ -223,6 +328,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
         },
+        "messages.outbound.realtime.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime messages that failed (which did not succeed for some reason other than Ably rejecting it, such as being rejected by an external integration target)"
+        },
+        "messages.outbound.realtime.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime messages that were refused by Ably (generally due to rate limits)"
+        },
         "messages.outbound.realtime.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -238,6 +353,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
         },
+        "messages.outbound.realtime.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.outbound.realtime.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+        },
         "messages.outbound.realtime.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -252,6 +377,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.realtime.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+        },
+        "messages.outbound.realtime.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound realtime presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.rest.all.count": {
           "type": "number",
@@ -301,47 +436,77 @@
         "messages.outbound.webhook.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook message count (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound Webhook message count (sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook message size (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound Webhook message size (sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+        },
+        "messages.outbound.webhook.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+        },
+        "messages.outbound.webhook.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook message count (sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total outbound Webhook message count (sent from the Ably service to clients using Webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook message size (sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total outbound Webhook message size (sent from the Ably service to clients using Webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
+        },
+        "messages.outbound.webhook.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+        },
+        "messages.outbound.webhook.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook messages excluding presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook presence message count (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound Webhook presence message count (sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.presence.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Webhook presence message size (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound Webhook presence message size (sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+        },
+        "messages.outbound.webhook.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+        },
+        "messages.outbound.webhook.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound Webhook presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.sharedQueue.all.count": {
           "type": "number",
@@ -358,6 +523,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
         },
+        "messages.outbound.sharedQueue.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue messages that failed (which were rejected by RabbitMQ for some reason)"
+        },
+        "messages.outbound.sharedQueue.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue messages that Ably refused to send (generally due to a rate limit)"
+        },
         "messages.outbound.sharedQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -372,6 +547,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
+        },
+        "messages.outbound.sharedQueue.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue messages excluding presence messages that failed (which were rejected by RabbitMQ for some reason)"
+        },
+        "messages.outbound.sharedQueue.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.presence.count": {
           "type": "number",
@@ -388,6 +573,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
         },
+        "messages.outbound.sharedQueue.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue presence messages that failed (which were rejected by RabbitMQ for some reason)"
+        },
+        "messages.outbound.sharedQueue.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Queue presence messages that Ably refused to send (generally due to a rate limit)"
+        },
         "messages.outbound.externalQueue.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -402,6 +597,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+        },
+        "messages.outbound.externalQueue.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose messages that failed (which were rejected by the external integration target for some reason)"
+        },
+        "messages.outbound.externalQueue.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.messages.count": {
           "type": "number",
@@ -418,6 +623,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
         },
+        "messages.outbound.externalQueue.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose messages excluding presence messages that failed (which were rejected by the external integration target for some reason)"
+        },
+        "messages.outbound.externalQueue.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+        },
         "messages.outbound.externalQueue.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -432,6 +647,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+        },
+        "messages.outbound.externalQueue.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose presence messages that failed (which were rejected by the external integration target for some reason)"
+        },
+        "messages.outbound.externalQueue.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Reactor Firehose presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.all.count": {
           "type": "number",
@@ -448,6 +673,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
+        "messages.outbound.httpEvent.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages sent by a HTTP trigger that failed (which were rejected by the external endpoint for some reason)"
+        },
+        "messages.outbound.httpEvent.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages sent by a HTTP trigger that Ably refused to send (generally due to a rate limit)"
+        },
         "messages.outbound.httpEvent.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -462,6 +697,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+        },
+        "messages.outbound.httpEvent.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages sent by a HTTP trigger excluding presence messages that failed (which were rejected by the external endpoint for some reason)"
+        },
+        "messages.outbound.httpEvent.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages sent by a HTTP trigger excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.presence.count": {
           "type": "number",
@@ -478,6 +723,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
+        "messages.outbound.httpEvent.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of presence messages sent by a HTTP trigger that failed (which were rejected by the external endpoint for some reason)"
+        },
+        "messages.outbound.httpEvent.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of presence messages sent by a HTTP trigger that Ably refused to send (generally due to a rate limit)"
+        },
         "messages.outbound.push.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -492,6 +747,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+        },
+        "messages.outbound.push.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+        },
+        "messages.outbound.push.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push messages that were refused by Ably (eg due to a rate limit)"
         },
         "messages.outbound.push.messages.count": {
           "type": "number",
@@ -508,6 +773,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
         },
+        "messages.outbound.push.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+        },
+        "messages.outbound.push.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push messages excluding presence messages that were refused by Ably (eg due to a rate limit)"
+        },
         "messages.outbound.push.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -522,6 +797,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+        },
+        "messages.outbound.push.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+        },
+        "messages.outbound.push.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of Push presence messages that were refused by Ably (eg due to a rate limit)"
         },
         "messages.outbound.all.all.count": {
           "type": "number",
@@ -538,6 +823,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
         },
+        "messages.outbound.all.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.outbound.all.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound messages that were refused by Ably (generally due to rate limits)"
+        },
         "messages.outbound.all.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -553,6 +848,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
         },
+        "messages.outbound.all.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.outbound.all.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+        },
         "messages.outbound.all.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -567,6 +872,16 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.all.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+        },
+        "messages.outbound.all.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of outbound presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.persisted.all.count": {
           "type": "number",
@@ -681,7 +996,7 @@
         "connections.all.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of connections refused."
+          "description": "Total number of connections refused, eg for breaching the connection creation rate limit."
         },
         "channels.peak": {
           "type": "number",
@@ -706,7 +1021,7 @@
         "channels.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of channel attach requests that failed because of permissions."
+          "description": "Total number of channel creation rejected for breaching the channel creation rate limit."
         },
         "apiRequests.all.succeeded": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -928,50 +928,20 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
-        "messages.processed.all.count": {
+        "messages.processed.delta.xdelta.succeeded": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total processed message count based on configured channel rules."
+          "description": "Total number of message deltas successfully generated (using xdelta, currently the only supported codec), see https://ably.com/docs/channels/options/deltas."
         },
-        "messages.processed.all.data": {
+        "messages.processed.delta.xdelta.skipped": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total processed message size based on configured channel rules."
+          "description": "Total number of messages on channels where delta generation was enabled but where we skipped delta generation, eg because the payload was too small to make it worthwhile, see https://ably.com/docs/channels/options/deltas."
         },
-        "messages.processed.all.uncompressedData": {
+        "messages.processed.delta.xdelta.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
-        },
-        "messages.processed.messages.count": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total processed message count based on configured channel rules, excluding presence messages."
-        },
-        "messages.processed.messages.data": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total processed message size based on configured channel rules, excluding presence messages."
-        },
-        "messages.processed.messages.uncompressedData": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules, excluding presence messages."
-        },
-        "messages.processed.presence.count": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total processed presence message count based on configured channel rules."
-        },
-        "messages.processed.presence.data": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total processed presence message size based on configured channel rules."
-        },
-        "messages.processed.presence.uncompressedData": {
-          "type": "number",
-          "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
+          "description": "Total number of messages on channels where delta generation was attempted but where a delta was not successfully generated, so we just broadcast the original, see https://ably.com/docs/channels/options/deltas."
         },
         "connections.all.peak": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -511,152 +511,152 @@
         "messages.outbound.sharedQueue.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue message count (sent from the Ably service to a Reactor Queue)."
+          "description": "Total Ably Queue message count (sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue message size (sent from the Ably service to a Reactor Queue)."
+          "description": "Total Ably Queue message size (sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Ably Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue messages that failed (which were rejected by RabbitMQ for some reason)"
+          "description": "Total number of Ably Queue messages that failed (which were rejected by RabbitMQ for some reason)"
         },
         "messages.outbound.sharedQueue.all.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Ably Queue messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue message count (sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total Ably Queue message count (sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue message size (sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total Ably Queue message size (sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total uncompressed Ably Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue messages excluding presence messages that failed (which were rejected by RabbitMQ for some reason)"
+          "description": "Total number of Ably Queue messages excluding presence messages that failed (which were rejected by RabbitMQ for some reason)"
         },
         "messages.outbound.sharedQueue.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Ably Queue messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue presence message count (sent from the Ably service to a Reactor Queue)."
+          "description": "Total Ably Queue presence message count (sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.presence.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Queue presence message size (sent from the Ably service to a Reactor Queue)."
+          "description": "Total Ably Queue presence message size (sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Ably Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue presence messages that failed (which were rejected by RabbitMQ for some reason)"
+          "description": "Total number of Ably Queue presence messages that failed (which were rejected by RabbitMQ for some reason)"
         },
         "messages.outbound.sharedQueue.presence.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Queue presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Ably Queue presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose message count (sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total Firehose message count (sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose message size (sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total Firehose message size (sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose messages that failed (which were rejected by the external integration target for some reason)"
+          "description": "Total number of Firehose messages that failed (which were rejected by the external integration target for some reason)"
         },
         "messages.outbound.externalQueue.all.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Firehose messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose message count (sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total Firehose message count (sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose message size (sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total Firehose message size (sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total uncompressed Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose messages excluding presence messages that failed (which were rejected by the external integration target for some reason)"
+          "description": "Total number of Firehose messages excluding presence messages that failed (which were rejected by the external integration target for some reason)"
         },
         "messages.outbound.externalQueue.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Firehose messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose presence message count (sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total Firehose presence message count (sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.presence.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Reactor Firehose presence message size (sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total Firehose presence message size (sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose presence messages that failed (which were rejected by the external integration target for some reason)"
+          "description": "Total number of Firehose presence messages that failed (which were rejected by the external integration target for some reason)"
         },
         "messages.outbound.externalQueue.presence.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Reactor Firehose presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Firehose presence messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.all.count": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -46,7 +46,7 @@
         "messages.all.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.all.refused": {
           "type": "number",
@@ -66,12 +66,12 @@
         "messages.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.refused": {
           "type": "number",
@@ -96,7 +96,7 @@
         "messages.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.refused": {
           "type": "number",
@@ -121,7 +121,7 @@
         "messages.inbound.realtime.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound realtime messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.realtime.all.refused": {
           "type": "number",
@@ -146,7 +146,7 @@
         "messages.inbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as ejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as ejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.inbound.realtime.messages.refused": {
           "type": "number",
@@ -171,7 +171,7 @@
         "messages.inbound.realtime.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound realtime presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.realtime.presence.refused": {
           "type": "number",
@@ -196,7 +196,7 @@
         "messages.inbound.rest.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.rest.all.refused": {
           "type": "number",
@@ -236,7 +236,7 @@
         "messages.inbound.rest.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound REST presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound REST presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.rest.presence.refused": {
           "type": "number",
@@ -261,7 +261,7 @@
         "messages.inbound.all.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.all.refused": {
           "type": "number",
@@ -286,7 +286,7 @@
         "messages.inbound.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.presence.count": {
           "type": "number",
@@ -306,7 +306,7 @@
         "messages.inbound.all.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.presence.refused": {
           "type": "number",
@@ -356,7 +356,7 @@
         "messages.outbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of outbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.outbound.realtime.messages.refused": {
           "type": "number",
@@ -381,7 +381,7 @@
         "messages.outbound.realtime.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as a service issue on Ably's side)"
+          "description": "Total number of outbound realtime presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.outbound.realtime.presence.refused": {
           "type": "number",
@@ -451,7 +451,7 @@
         "messages.outbound.webhook.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound Webhook messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.all.refused": {
           "type": "number",
@@ -476,7 +476,7 @@
         "messages.outbound.webhook.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound Webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.messages.refused": {
           "type": "number",
@@ -501,7 +501,7 @@
         "messages.outbound.webhook.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound Webhook presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.presence.refused": {
           "type": "number",
@@ -751,7 +751,7 @@
         "messages.outbound.push.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+          "description": "Total number of Push messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
         },
         "messages.outbound.push.all.refused": {
           "type": "number",
@@ -776,7 +776,7 @@
         "messages.outbound.push.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+          "description": "Total number of Push messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
         },
         "messages.outbound.push.messages.refused": {
           "type": "number",
@@ -801,7 +801,7 @@
         "messages.outbound.push.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+          "description": "Total number of Push presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
         },
         "messages.outbound.push.presence.refused": {
           "type": "number",
@@ -826,7 +826,7 @@
         "messages.outbound.all.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of outbound messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
         },
         "messages.outbound.all.all.refused": {
           "type": "number",
@@ -851,7 +851,7 @@
         "messages.outbound.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of outbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
         },
         "messages.outbound.all.messages.refused": {
           "type": "number",
@@ -876,7 +876,7 @@
         "messages.outbound.all.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound presence messages that failed (which did not succeed for some reason other than Ably actively rejecting it, such as rejection by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of outbound presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
         },
         "messages.outbound.all.presence.refused": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -91,7 +91,7 @@
         "messages.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas)."
+          "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas)."
         },
         "messages.all.messages.failed": {
           "type": "number",
@@ -116,7 +116,7 @@
         "messages.inbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.realtime.all.failed": {
           "type": "number",
@@ -141,7 +141,7 @@
         "messages.inbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
         },
         "messages.inbound.realtime.messages.failed": {
           "type": "number",
@@ -166,7 +166,7 @@
         "messages.inbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.realtime.presence.failed": {
           "type": "number",
@@ -191,7 +191,7 @@
         "messages.inbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.rest.all.failed": {
           "type": "number",
@@ -216,7 +216,7 @@
         "messages.inbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
         },
         "messages.inbound.rest.presence.count": {
           "type": "number",
@@ -231,7 +231,7 @@
         "messages.inbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.rest.presence.failed": {
           "type": "number",
@@ -256,7 +256,7 @@
         "messages.inbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.all.all.failed": {
           "type": "number",
@@ -281,7 +281,7 @@
         "messages.inbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
         },
         "messages.inbound.all.messages.failed": {
           "type": "number",
@@ -301,7 +301,7 @@
         "messages.inbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
         },
         "messages.inbound.all.presence.failed": {
           "type": "number",
@@ -326,7 +326,7 @@
         "messages.outbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.realtime.all.failed": {
           "type": "number",
@@ -351,7 +351,7 @@
         "messages.outbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.realtime.messages.failed": {
           "type": "number",
@@ -376,7 +376,7 @@
         "messages.outbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.realtime.presence.failed": {
           "type": "number",
@@ -401,7 +401,7 @@
         "messages.outbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.rest.messages.count": {
           "type": "number",
@@ -416,7 +416,7 @@
         "messages.outbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",
@@ -431,7 +431,7 @@
         "messages.outbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.webhook.all.count": {
           "type": "number",
@@ -446,7 +446,7 @@
         "messages.outbound.webhook.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.all.failed": {
           "type": "number",
@@ -471,7 +471,7 @@
         "messages.outbound.webhook.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.failed": {
           "type": "number",
@@ -496,7 +496,7 @@
         "messages.outbound.webhook.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks)."
         },
         "messages.outbound.webhook.presence.failed": {
           "type": "number",
@@ -521,7 +521,7 @@
         "messages.outbound.sharedQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue)."
         },
         "messages.outbound.sharedQueue.all.failed": {
           "type": "number",
@@ -546,7 +546,7 @@
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
+          "description": "Total uncompressed Reactor Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.failed": {
           "type": "number",
@@ -571,7 +571,7 @@
         "messages.outbound.sharedQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to a Reactor Queue)."
+          "description": "Total uncompressed Reactor Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to a Reactor Queue)."
         },
         "messages.outbound.sharedQueue.presence.failed": {
           "type": "number",
@@ -596,7 +596,7 @@
         "messages.outbound.externalQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose)."
         },
         "messages.outbound.externalQueue.all.failed": {
           "type": "number",
@@ -621,7 +621,7 @@
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
+          "description": "Total uncompressed Reactor Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.failed": {
           "type": "number",
@@ -646,7 +646,7 @@
         "messages.outbound.externalQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to some external target using Reactor Firehose)."
+          "description": "Total uncompressed Reactor Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using Reactor Firehose)."
         },
         "messages.outbound.externalQueue.presence.failed": {
           "type": "number",
@@ -671,7 +671,7 @@
         "messages.outbound.httpEvent.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "messages.outbound.httpEvent.all.failed": {
           "type": "number",
@@ -696,7 +696,7 @@
         "messages.outbound.httpEvent.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
         },
         "messages.outbound.httpEvent.messages.failed": {
           "type": "number",
@@ -721,7 +721,7 @@
         "messages.outbound.httpEvent.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "messages.outbound.httpEvent.presence.failed": {
           "type": "number",
@@ -746,7 +746,7 @@
         "messages.outbound.push.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
         },
         "messages.outbound.push.all.failed": {
           "type": "number",
@@ -771,7 +771,7 @@
         "messages.outbound.push.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
         },
         "messages.outbound.push.messages.failed": {
           "type": "number",
@@ -796,7 +796,7 @@
         "messages.outbound.push.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
         },
         "messages.outbound.push.presence.failed": {
           "type": "number",
@@ -821,7 +821,7 @@
         "messages.outbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.all.all.failed": {
           "type": "number",
@@ -846,7 +846,7 @@
         "messages.outbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.all.messages.failed": {
           "type": "number",
@@ -871,7 +871,7 @@
         "messages.outbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.all.presence.failed": {
           "type": "number",
@@ -896,7 +896,7 @@
         "messages.persisted.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
         "messages.persisted.messages.count": {
           "type": "number",
@@ -911,7 +911,7 @@
         "messages.persisted.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules, excluding presence messages."
         },
         "messages.persisted.presence.count": {
           "type": "number",
@@ -926,7 +926,7 @@
         "messages.persisted.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
         "messages.processed.all.count": {
           "type": "number",
@@ -941,7 +941,7 @@
         "messages.processed.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
         "messages.processed.messages.count": {
           "type": "number",
@@ -956,7 +956,7 @@
         "messages.processed.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed processed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules, excluding presence messages."
         },
         "messages.processed.presence.count": {
           "type": "number",
@@ -971,7 +971,7 @@
         "messages.processed.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed processed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/realtime/channels/channel-parameters/deltas) based on configured channel rules."
+          "description": "Total uncompressed processed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
         },
         "connections.all.peak": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -31,7 +31,7 @@
         "messages.all.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of successful messages, summed over all message types and transports."
+          "description": "Total number of successfully-sent messages, summed over all message types and transports."
         },
         "messages.all.all.data": {
           "type": "number",
@@ -41,7 +41,7 @@
         "messages.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas)."
+          "description": "Total uncompressed message size, excluding delta compression https://ably.com/docs/channels/options/deltas."
         },
         "messages.all.all.failed": {
           "type": "number",
@@ -91,7 +91,7 @@
         "messages.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas)."
+          "description": "Total uncompressed presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas."
         },
         "messages.all.messages.failed": {
           "type": "number",
@@ -116,7 +116,7 @@
         "messages.inbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.realtime.all.failed": {
           "type": "number",
@@ -141,12 +141,12 @@
         "messages.inbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
         },
         "messages.inbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as ejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.inbound.realtime.messages.refused": {
           "type": "number",
@@ -166,7 +166,7 @@
         "messages.inbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound realtime presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.realtime.presence.failed": {
           "type": "number",
@@ -191,7 +191,7 @@
         "messages.inbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.rest.all.failed": {
           "type": "number",
@@ -216,7 +216,7 @@
         "messages.inbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
         },
         "messages.inbound.rest.presence.count": {
           "type": "number",
@@ -231,7 +231,7 @@
         "messages.inbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound REST presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.rest.presence.failed": {
           "type": "number",
@@ -256,7 +256,7 @@
         "messages.inbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.all.all.failed": {
           "type": "number",
@@ -281,7 +281,7 @@
         "messages.inbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients), excluding presence messages."
+          "description": "Total uncompressed inbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
         },
         "messages.inbound.all.messages.failed": {
           "type": "number",
@@ -301,7 +301,7 @@
         "messages.inbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, received by the Ably service from clients)."
+          "description": "Total uncompressed inbound presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
         },
         "messages.inbound.all.presence.failed": {
           "type": "number",
@@ -326,7 +326,7 @@
         "messages.outbound.realtime.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.realtime.all.failed": {
           "type": "number",
@@ -351,7 +351,7 @@
         "messages.outbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.realtime.messages.failed": {
           "type": "number",
@@ -376,7 +376,7 @@
         "messages.outbound.realtime.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound realtime presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.realtime.presence.failed": {
           "type": "number",
@@ -401,7 +401,7 @@
         "messages.outbound.rest.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.rest.messages.count": {
           "type": "number",
@@ -416,7 +416,7 @@
         "messages.outbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",
@@ -431,82 +431,82 @@
         "messages.outbound.rest.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound REST presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.webhook.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook message count (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound webhook message count (sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook message size (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound webhook message size (sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound webhook message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.all.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound webhook messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.all.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound webhook messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook message count (sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total outbound webhook message count (sent from the Ably service to clients using webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook message size (sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total outbound webhook message size (sent from the Ably service to clients using webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks), excluding presence messages."
+          "description": "Total uncompressed outbound webhook message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks), excluding presence messages."
         },
         "messages.outbound.webhook.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound webhook messages excluding presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook presence message count (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound webhook presence message count (sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.presence.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound Webhook presence message size (sent from the Ably service to clients using Webhooks)."
+          "description": "Total outbound webhook presence message size (sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound Webhook presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using Webhooks)."
+          "description": "Total uncompressed outbound webhook presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks)."
         },
         "messages.outbound.webhook.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound webhook presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.presence.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound Webhook presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound webhook presence messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.sharedQueue.all.count": {
           "type": "number",
@@ -521,7 +521,7 @@
         "messages.outbound.sharedQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Ably Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
+          "description": "Total uncompressed Ably Queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.all.failed": {
           "type": "number",
@@ -546,7 +546,7 @@
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Ably Queue message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
+          "description": "Total uncompressed Ably Queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
         },
         "messages.outbound.sharedQueue.messages.failed": {
           "type": "number",
@@ -571,7 +571,7 @@
         "messages.outbound.sharedQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Ably Queue presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
+          "description": "Total uncompressed Ably Queue presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule)."
         },
         "messages.outbound.sharedQueue.presence.failed": {
           "type": "number",
@@ -596,7 +596,7 @@
         "messages.outbound.externalQueue.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
+          "description": "Total uncompressed Firehose message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.all.failed": {
           "type": "number",
@@ -621,7 +621,7 @@
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Firehose message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
+          "description": "Total uncompressed Firehose message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
         },
         "messages.outbound.externalQueue.messages.failed": {
           "type": "number",
@@ -646,7 +646,7 @@
         "messages.outbound.externalQueue.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Firehose presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
+          "description": "Total uncompressed Firehose presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule)."
         },
         "messages.outbound.externalQueue.presence.failed": {
           "type": "number",
@@ -671,7 +671,7 @@
         "messages.outbound.httpEvent.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "messages.outbound.httpEvent.all.failed": {
           "type": "number",
@@ -696,7 +696,7 @@
         "messages.outbound.httpEvent.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
         },
         "messages.outbound.httpEvent.messages.failed": {
           "type": "number",
@@ -721,7 +721,7 @@
         "messages.outbound.httpEvent.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of presence messages sent by a HTTP trigger (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
+          "description": "Total uncompressed size of presence messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions)."
         },
         "messages.outbound.httpEvent.presence.failed": {
           "type": "number",
@@ -746,7 +746,7 @@
         "messages.outbound.push.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
         },
         "messages.outbound.push.all.failed": {
           "type": "number",
@@ -771,7 +771,7 @@
         "messages.outbound.push.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total uncompressed Push message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
         },
         "messages.outbound.push.messages.failed": {
           "type": "number",
@@ -796,7 +796,7 @@
         "messages.outbound.push.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
+          "description": "Total uncompressed Push presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS)."
         },
         "messages.outbound.push.presence.failed": {
           "type": "number",
@@ -821,7 +821,7 @@
         "messages.outbound.all.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.all.all.failed": {
           "type": "number",
@@ -846,7 +846,7 @@
         "messages.outbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
         },
         "messages.outbound.all.messages.failed": {
           "type": "number",
@@ -871,7 +871,7 @@
         "messages.outbound.all.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+          "description": "Total uncompressed outbound presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
         "messages.outbound.all.presence.failed": {
           "type": "number",
@@ -896,7 +896,7 @@
         "messages.persisted.all.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules."
         },
         "messages.persisted.messages.count": {
           "type": "number",
@@ -911,7 +911,7 @@
         "messages.persisted.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed persisted message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules, excluding presence messages."
         },
         "messages.persisted.presence.count": {
           "type": "number",
@@ -926,7 +926,7 @@
         "messages.persisted.presence.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted presence message size (excluding any compression, e.g. delta compression: https://ably.com/docs/channels/options/deltas) based on configured channel rules."
+          "description": "Total uncompressed persisted presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules."
         },
         "messages.processed.delta.xdelta.succeeded": {
           "type": "number",
@@ -936,12 +936,12 @@
         "messages.processed.delta.xdelta.skipped": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages on channels where delta generation was enabled but where we skipped delta generation, eg because the payload was too small to make it worthwhile, see https://ably.com/docs/channels/options/deltas."
+          "description": "Total number of messages on channels where delta generation was enabled but where Ably skipped delta generation, eg because the payload was too small to make it worthwhile, see https://ably.com/docs/channels/options/deltas."
         },
         "messages.processed.delta.xdelta.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages on channels where delta generation was attempted but where a delta was not successfully generated, so we just broadcast the original, see https://ably.com/docs/channels/options/deltas."
+          "description": "Total number of messages on channels where delta generation was attempted but where a delta was not successfully generated, so Ably just broadcasted the original, see https://ably.com/docs/channels/options/deltas."
         },
         "connections.all.peak": {
           "type": "number",


### PR DESCRIPTION
REA-1986

Lots of failed and refused entries were missing, probably because they were missing from https://ably.com/docs/metadata-stats/stats and I think this was probably originally created from that.

The `processed` stats (delta generation) were also completely wrong.

Also updated the terminology to our current stuff (we don't say "reactor" any more, etc)