### PR TITLE
JSON schemas: bump version of stats

### DIFF
--- a/json-schemas/versions.json
+++ b/json-schemas/versions.json
@@ -1,7 +1,7 @@
 {
   "agents": "0.0.2",
-  "account-stats": "0.0.2",
-  "app-stats": "0.0.4",
+  "account-stats": "0.0.3",
+  "app-stats": "0.0.5",
   "client-events-api-requests": "0.0.1",
   "client-events-connections": "0.0.1",
   "channel-lifecycle": "0.0.1",


### PR DESCRIPTION
About half a second after I merged https://github.com/ably/ably-common/pull/255 I realised I forgot to bump the schema version