### PR TITLE
Add unbatched outbound stats

### DIFF
--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -93,12 +93,12 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas."
         },
-        "messages.all.messages.failed": {
+        "messages.all.presence.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
-        "messages.all.messages.refused": {
+        "messages.all.presence.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of presence messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
@@ -318,6 +318,11 @@
           "inclusiveMinimum": 0,
           "description": "Total outbound realtime message count (sent from the Ably service to clients)."
         },
+        "messages.outbound.realtime.all.unbatchedCount": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound realtime message count (sent from the Ably service to clients) without considering the effects of server-side batching."
+        },
         "messages.outbound.realtime.all.data": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -343,6 +348,11 @@
           "inclusiveMinimum": 0,
           "description": "Total outbound realtime message count (sent from the Ably service to clients), excluding presence messages."
         },
+        "messages.outbound.realtime.messages.unbatchedCount": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound realtime message count (sent from the Ably service to clients), excluding presence messages and without considering the effects of server-side batching."
+        },
         "messages.outbound.realtime.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -367,6 +377,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total outbound realtime presence message count (sent from the Ably service to clients)."
+        },
+        "messages.outbound.realtime.presence.unbatchedCount": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound realtime presence message count (sent from the Ably service to clients) without considering the effects of server-side batching."
         },
         "messages.outbound.realtime.presence.data": {
           "type": "number",


### PR DESCRIPTION
https://ably.atlassian.net/browse/REA-1946

Adding unbatched outbound stats counts to have a comparison point with the batched results. If batching is disabled, it should contain the same value as the simple `.count` counterpart stat.