### PR TITLE
json-schemas: add state subscriber occupancy metric

### DIFF
--- a/json-schemas/src/attachments.json
+++ b/json-schemas/src/attachments.json
@@ -54,7 +54,8 @@
             "metrics.subscribers",
             "metrics.presenceConnections",
             "metrics.presenceMembers",
-            "metrics.presenceSubscribers"
+            "metrics.presenceSubscribers",
+            "metrics.stateSubscribers"
           ]
         }
       }


### PR DESCRIPTION
Part of [DTP-848](https://ably.atlassian.net/browse/DTP-848)

[DTP-848]: https://ably.atlassian.net/browse/DTP-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ