### PR TITLE
add state publishers occupancy metric

### DIFF
--- a/json-schemas/src/attachments.json
+++ b/json-schemas/src/attachments.json
@@ -55,7 +55,8 @@
             "metrics.presenceConnections",
             "metrics.presenceMembers",
             "metrics.presenceSubscribers",
-            "metrics.stateSubscribers"
+            "metrics.stateSubscribers",
+            "metrics.statePublishers"
           ]
         }
       }


### PR DESCRIPTION
part of [DTP-848](https://ably.atlassian.net/browse/DTP-848)

[DTP-848]: https://ably.atlassian.net/browse/DTP-848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ