### PR TITLE
add 'requires newer protocol version' error code

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -26,6 +26,7 @@
   "40020": "Batch error",
   "40021": "Feature requires a newer platform version",
   "40022": "API Streamer has been shut down",
+  "40023": "Action requires a newer protocol version",
   "40030": "Invalid publish request (unspecified)",
   "40031": "Invalid publish request (invalid client-specified id)",
   "40032": "Invalid publish request (impermissible extras field)",


### PR DESCRIPTION
the intention is to use this error code when a client attempts to attach to a channel with a state mode when connected to a frontend