### PR TITLE
feat: update account and app json schemas with state

### DIFF
--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -189,6 +189,31 @@
           "inclusiveMinimum": 0,
           "description": "Total number of inbound realtime presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
+        "messages.inbound.realtime.state.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound realtime state message count (received by the Ably service from clients)."
+        },
+        "messages.inbound.realtime.state.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound realtime state message size (received by the Ably service from clients)."
+        },
+        "messages.inbound.realtime.state.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound realtime state message size received by the Ably service from clients."
+        },
+        "messages.inbound.realtime.state.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.realtime.state.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
         "messages.inbound.rest.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -413,6 +438,29 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of outbound realtime presence messages that were refused by Ably (generally due to rate limits)"
+        },
+        "messages.outbound.realtime.state.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound realtime state message count (sent from the Ably service to clients)."
+        },
+
+        "messages.outbound.realtime.state.billableCount": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total billable outbound realtime state message count (sent from the Ably service to clients)."
+        },
+
+        "messages.outbound.realtime.state.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound realtime state message size (sent from the Ably service to clients)."
+        },
+
+        "messages.outbound.realtime.state.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed outbound realtime presence message size sent from the Ably service to clients)."
         },
         "messages.outbound.rest.all.count": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -193,6 +193,31 @@
           "inclusiveMinimum": 0,
           "description": "Total number of inbound realtime presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
+        "messages.inbound.realtime.state.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound realtime state message count (received by the Ably service from clients)."
+        },
+        "messages.inbound.realtime.state.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound realtime state message size (received by the Ably service from clients)."
+        },
+        "messages.inbound.realtime.state.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound realtime state message size received by the Ably service from clients."
+        },
+        "messages.inbound.realtime.state.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.realtime.state.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound realtime state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
         "messages.inbound.rest.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -417,6 +442,29 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of outbound realtime presence messages that were refused by Ably (generally due to rate limits)"
+        },
+        "messages.outbound.realtime.state.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound realtime state message count (sent from the Ably service to clients)."
+        },
+
+        "messages.outbound.realtime.state.billableCount": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total billable outbound realtime state message count (sent from the Ably service to clients)."
+        },
+
+        "messages.outbound.realtime.state.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound realtime state message size (sent from the Ably service to clients)."
+        },
+
+        "messages.outbound.realtime.state.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed outbound realtime presence message size sent from the Ably service to clients)."
         },
         "messages.outbound.rest.all.count": {
           "type": "number",


### PR DESCRIPTION
Add the current state message realtime inbound and outbound stats to the account and application stats message schemas.