### PR TITLE
feat: update state error code 92001

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -195,7 +195,7 @@
   "91100": "member implicitly left presence channel (connection closed)",
 
   "92000": "invalid state message",
-  "92001": "state max objects limit",
+  "92001": "state limit exceeded",
   "92002": "unable to submit operation on tombstone object",
 
   "101000": "must have a non-empty name for the space",


### PR DESCRIPTION
The code 92001 was prevoiusly used to signal that max object size limit had been exceeded. This has now been updated to be more generaly capturing a number of state limits that could be exceeded.