### PR TITLE
feat: DTP-1126 Update App and Account stats schemas with state messages

### DIFF
--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -289,6 +289,31 @@
           "inclusiveMinimum": 0,
           "description": "Total number of inbound REST presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
+        "messages.inbound.rest.state.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound REST state message count (received by the Ably service from clients)."
+        },
+        "messages.inbound.rest.state.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound REST state message size (received by the Ably service from clients)."
+        },
+        "messages.inbound.rest.state.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound REST state message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
+        },
+        "messages.inbound.rest.state.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)."
+        },
+        "messages.inbound.rest.state.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)."
+        },
         "messages.inbound.all.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -526,6 +551,26 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound REST presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.rest.state.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound REST state message count (sent from the Ably service to clients)."
+        },
+        "messages.outbound.rest.state.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound REST state message size (sent from the Ably service to clients)."
+        },
+        "messages.outbound.rest.state.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed outbound REST state message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.rest.state.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of state messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter."
         },
         "messages.outbound.webhook.all.count": {
           "type": "number",

--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -57,17 +57,17 @@
         "messages.all.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total message count, excluding presence messages."
+          "description": "Total message count, excluding presence and state messages."
         },
         "messages.all.messages.billableCount": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages that are billable, excluding presence messages."
+          "description": "Total number of messages that are billable, excluding presence and state messages."
         },
         "messages.all.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total message size, excluding presence messages."
+          "description": "Total message size, excluding presence and state messages."
         },
         "messages.all.messages.uncompressedData": {
           "type": "number",
@@ -77,12 +77,12 @@
         "messages.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+          "description": "Total number of messages excluding presence and state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.all.presence.count": {
           "type": "number",
@@ -107,12 +107,12 @@
         "messages.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of presence messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of presence messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+          "description": "Total number of presence messages excluding presence and state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.realtime.all.count": {
           "type": "number",
@@ -142,27 +142,27 @@
         "messages.inbound.realtime.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound realtime message count (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound realtime message count (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.realtime.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound realtime message size (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound realtime message size (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
+          "description": "Total uncompressed inbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence and state messages."
         },
         "messages.inbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of inbound realtime messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.inbound.realtime.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+          "description": "Total number of inbound realtime messages excluding presence and state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.realtime.presence.count": {
           "type": "number",
@@ -242,27 +242,27 @@
         "messages.inbound.rest.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound REST message count (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound REST message count (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.rest.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound REST message size (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound REST message size (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
+          "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence and state messages."
         },
         "messages.inbound.rest.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side), excluding presence & state messages."
+          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side), excluding presence and state messages."
         },
         "messages.inbound.rest.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound REST messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part), excluding presence & state messages."
+          "description": "Total number of inbound REST messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part), excluding presence and state messages."
         },
         "messages.inbound.rest.presence.count": {
           "type": "number",
@@ -342,22 +342,22 @@
         "messages.inbound.all.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound message count (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound message count (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.all.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound message size (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound message size (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
+          "description": "Total uncompressed inbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence and state messages."
         },
         "messages.inbound.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.presence.count": {
           "type": "number",
@@ -417,32 +417,32 @@
         "messages.outbound.realtime.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound realtime message count (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound realtime message count (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.realtime.messages.billableCount": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime messages that are billable (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total number of outbound realtime messages that are billable (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.realtime.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound realtime message size (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound realtime message size (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+          "description": "Total number of outbound realtime messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.outbound.realtime.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound realtime messages excluding presence and state messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.realtime.presence.count": {
           "type": "number",
@@ -520,22 +520,22 @@
         "messages.outbound.rest.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound REST message count (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound REST message count (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.rest.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound REST message size (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound REST message size (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.rest.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter, excluding presence & state messages"
+          "description": "Total number of messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter, excluding presence and state messages"
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",
@@ -600,27 +600,27 @@
         "messages.outbound.webhook.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound webhook message count (sent from the Ably service to clients using webhooks), excluding presence messages."
+          "description": "Total outbound webhook message count (sent from the Ably service to clients using webhooks), excluding presence and state messages."
         },
         "messages.outbound.webhook.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound webhook message size (sent from the Ably service to clients using webhooks), excluding presence messages."
+          "description": "Total outbound webhook message size (sent from the Ably service to clients using webhooks), excluding presence and state messages."
         },
         "messages.outbound.webhook.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound webhook message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks), excluding presence messages."
+          "description": "Total uncompressed outbound webhook message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks), excluding presence and state messages."
         },
         "messages.outbound.webhook.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound webhook messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound webhook messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound webhook messages excluding presence and state messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.presence.count": {
           "type": "number",
@@ -675,27 +675,27 @@
         "messages.outbound.sharedQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Ably Queue message count (sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
+          "description": "Total Ably Queue message count (sent from the Ably service to an Ably Queue using an integration rule), excluding presence and state messages."
         },
         "messages.outbound.sharedQueue.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Ably Queue message size (sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
+          "description": "Total Ably Queue message size (sent from the Ably service to an Ably Queue using an integration rule), excluding presence and state messages."
         },
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Ably Queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
+          "description": "Total uncompressed Ably Queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence and state messages."
         },
         "messages.outbound.sharedQueue.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Ably Queue messages excluding presence messages that failed (which were rejected by RabbitMQ for some reason)"
+          "description": "Total number of Ably Queue messages excluding presence and state messages that failed (which were rejected by RabbitMQ for some reason)"
         },
         "messages.outbound.sharedQueue.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Ably Queue messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Ably Queue messages excluding presence and state messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.presence.count": {
           "type": "number",
@@ -750,27 +750,27 @@
         "messages.outbound.externalQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Firehose message count (sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
+          "description": "Total Firehose message count (sent from the Ably service to some external target using a Firehose integration rule), excluding presence and state messages."
         },
         "messages.outbound.externalQueue.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Firehose message size (sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
+          "description": "Total Firehose message size (sent from the Ably service to some external target using a Firehose integration rule), excluding presence and state messages."
         },
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Firehose message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
+          "description": "Total uncompressed Firehose message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence and state messages."
         },
         "messages.outbound.externalQueue.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Firehose messages excluding presence messages that failed (which were rejected by the external integration target for some reason)"
+          "description": "Total number of Firehose messages excluding presence and state messages that failed (which were rejected by the external integration target for some reason)"
         },
         "messages.outbound.externalQueue.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Firehose messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Firehose messages excluding presence and state messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.presence.count": {
           "type": "number",
@@ -825,27 +825,27 @@
         "messages.outbound.httpEvent.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total messages sent by a HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total messages sent by a HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence and state messages."
         },
         "messages.outbound.httpEvent.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total size of messages sent by a HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total size of messages sent by a HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence and state messages."
         },
         "messages.outbound.httpEvent.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence and state messages."
         },
         "messages.outbound.httpEvent.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages sent by a HTTP trigger excluding presence messages that failed (which were rejected by the external endpoint for some reason)"
+          "description": "Total number of messages sent by a HTTP trigger excluding presence and state messages that failed (which were rejected by the external endpoint for some reason)"
         },
         "messages.outbound.httpEvent.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages sent by a HTTP trigger excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of messages sent by a HTTP trigger excluding presence and state messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.presence.count": {
           "type": "number",
@@ -900,27 +900,27 @@
         "messages.outbound.push.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Push message count (pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total Push message count (pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence and state messages."
         },
         "messages.outbound.push.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Push message size (pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total Push message size (pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence and state messages."
         },
         "messages.outbound.push.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total uncompressed Push message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence and state messages."
         },
         "messages.outbound.push.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+          "description": "Total number of Push messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
         },
         "messages.outbound.push.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push messages excluding presence messages that were refused by Ably (eg due to a rate limit)"
+          "description": "Total number of Push messages excluding presence and state messages that were refused by Ably (eg due to a rate limit)"
         },
         "messages.outbound.push.presence.count": {
           "type": "number",
@@ -980,32 +980,32 @@
         "messages.outbound.all.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound message count (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound message count (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.all.messages.billableCount": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages that are billable (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total number of outbound messages that are billable (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.all.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound message size (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound message size (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of outbound messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
         },
         "messages.outbound.all.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound messages excluding presence and state messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.all.presence.count": {
           "type": "number",
@@ -1055,17 +1055,17 @@
         "messages.persisted.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total persisted message count based on configured channel rules, excluding presence messages."
+          "description": "Total persisted message count based on configured channel rules, excluding presence and state messages."
         },
         "messages.persisted.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total persisted message size based on configured channel rules, excluding presence messages."
+          "description": "Total persisted message size based on configured channel rules, excluding presence and state messages."
         },
         "messages.persisted.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed persisted message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules, excluding presence and state messages."
         },
         "messages.persisted.presence.count": {
           "type": "number",

--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -254,6 +254,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
         },
+        "messages.inbound.rest.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side), excluding presence & state messages."
+        },
+        "messages.inbound.rest.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part), excluding presence & state messages."
+        },
         "messages.inbound.rest.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -477,6 +487,11 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
+        "messages.outbound.rest.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter."
+        },
         "messages.outbound.rest.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -491,6 +506,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+        },
+        "messages.outbound.rest.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter, excluding presence & state messages"
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -61,17 +61,17 @@
         "messages.all.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total message count, excluding presence messages."
+          "description": "Total message count, excluding presence and state messages."
         },
         "messages.all.messages.billableCount": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total billable message count, excluding presence messages."
+          "description": "Total billable message count, excluding presence and state messages."
         },
         "messages.all.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total message size, excluding presence messages."
+          "description": "Total message size, excluding presence and state messages."
         },
         "messages.all.messages.uncompressedData": {
           "type": "number",
@@ -81,12 +81,12 @@
         "messages.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+          "description": "Total number of messages excluding presence and state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.all.presence.count": {
           "type": "number",
@@ -111,12 +111,12 @@
         "messages.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of presence messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of presence messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.all.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of presence messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+          "description": "Total number of presence messages excluding presence and state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.realtime.all.count": {
           "type": "number",
@@ -146,27 +146,27 @@
         "messages.inbound.realtime.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound realtime message count (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound realtime message count (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.realtime.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound realtime message size (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound realtime message size (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
+          "description": "Total uncompressed inbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence and state messages."
         },
         "messages.inbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of inbound realtime messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejected by an external integration target, or a service issue on Ably's side)"
         },
         "messages.inbound.realtime.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound realtime messages excluding presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+          "description": "Total number of inbound realtime messages excluding presence and state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
         "messages.inbound.realtime.presence.count": {
           "type": "number",
@@ -246,27 +246,27 @@
         "messages.inbound.rest.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound REST message count (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound REST message count (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.rest.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound REST message size (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound REST message size (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
+          "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence and state messages."
         },
         "messages.inbound.rest.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side), excluding presence & state messages."
+          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side), excluding presence and state messages."
         },
         "messages.inbound.rest.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound REST messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part), excluding presence & state messages."
+          "description": "Total number of inbound REST messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part), excluding presence and state messages."
         },
         "messages.inbound.rest.presence.count": {
           "type": "number",
@@ -346,22 +346,22 @@
         "messages.inbound.all.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound message count (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound message count (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.all.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total inbound message size (received by the Ably service from clients), excluding presence messages."
+          "description": "Total inbound message size (received by the Ably service from clients), excluding presence and state messages."
         },
         "messages.inbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed inbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
+          "description": "Total uncompressed inbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence and state messages."
         },
         "messages.inbound.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of inbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+          "description": "Total number of inbound messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.inbound.all.presence.count": {
           "type": "number",
@@ -421,32 +421,32 @@
         "messages.outbound.realtime.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound realtime message count (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound realtime message count (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.realtime.messages.billableCount": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total billable outbound realtime message count (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total billable outbound realtime message count (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.realtime.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound realtime message size (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound realtime message size (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.realtime.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound realtime message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.realtime.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+          "description": "Total number of outbound realtime messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
         },
         "messages.outbound.realtime.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound realtime messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound realtime messages excluding presence and state messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.realtime.presence.count": {
           "type": "number",
@@ -524,22 +524,22 @@
         "messages.outbound.rest.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound REST message count (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound REST message count (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.rest.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound REST message size (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound REST message size (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.rest.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.rest.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter, excluding presence & state messages"
+          "description": "Total number of messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter, excluding presence and state messages"
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",
@@ -604,27 +604,27 @@
         "messages.outbound.webhook.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound webhook message count (sent from the Ably service to clients using webhooks), excluding presence messages."
+          "description": "Total outbound webhook message count (sent from the Ably service to clients using webhooks), excluding presence and state messages."
         },
         "messages.outbound.webhook.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound webhook message size (sent from the Ably service to clients using webhooks), excluding presence messages."
+          "description": "Total outbound webhook message size (sent from the Ably service to clients using webhooks), excluding presence and state messages."
         },
         "messages.outbound.webhook.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound webhook message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks), excluding presence messages."
+          "description": "Total uncompressed outbound webhook message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients using webhooks), excluding presence and state messages."
         },
         "messages.outbound.webhook.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound webhook messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
+          "description": "Total number of outbound webhook messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, in particular rejection by an external integration target)"
         },
         "messages.outbound.webhook.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound webhook messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound webhook messages excluding presence and state messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.webhook.presence.count": {
           "type": "number",
@@ -679,27 +679,27 @@
         "messages.outbound.sharedQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Ably Queue message count (sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
+          "description": "Total Ably Queue message count (sent from the Ably service to an Ably Queue using an integration rule), excluding presence and state messages."
         },
         "messages.outbound.sharedQueue.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Ably Queue message size (sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
+          "description": "Total Ably Queue message size (sent from the Ably service to an Ably Queue using an integration rule), excluding presence and state messages."
         },
         "messages.outbound.sharedQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Ably Queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence messages."
+          "description": "Total uncompressed Ably Queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to an Ably Queue using an integration rule), excluding presence and state messages."
         },
         "messages.outbound.sharedQueue.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Ably Queue messages excluding presence messages that failed (which were rejected by RabbitMQ for some reason)"
+          "description": "Total number of Ably Queue messages excluding presence and state messages that failed (which were rejected by RabbitMQ for some reason)"
         },
         "messages.outbound.sharedQueue.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Ably Queue messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Ably Queue messages excluding presence and state messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.sharedQueue.presence.count": {
           "type": "number",
@@ -754,27 +754,27 @@
         "messages.outbound.externalQueue.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Firehose message count (sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
+          "description": "Total Firehose message count (sent from the Ably service to some external target using a Firehose integration rule), excluding presence and state messages."
         },
         "messages.outbound.externalQueue.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Firehose message size (sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
+          "description": "Total Firehose message size (sent from the Ably service to some external target using a Firehose integration rule), excluding presence and state messages."
         },
         "messages.outbound.externalQueue.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Firehose message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence messages."
+          "description": "Total uncompressed Firehose message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to some external target using a Firehose integration rule), excluding presence and state messages."
         },
         "messages.outbound.externalQueue.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Firehose messages excluding presence messages that failed (which were rejected by the external integration target for some reason)"
+          "description": "Total number of Firehose messages excluding presence and state messages that failed (which were rejected by the external integration target for some reason)"
         },
         "messages.outbound.externalQueue.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Firehose messages excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of Firehose messages excluding presence and state messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.externalQueue.presence.count": {
           "type": "number",
@@ -829,27 +829,27 @@
         "messages.outbound.httpEvent.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total messages sent by a HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total messages sent by a HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence and state messages."
         },
         "messages.outbound.httpEvent.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total size of messages sent by a HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total size of messages sent by a HTTP trigger (typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence and state messages."
         },
         "messages.outbound.httpEvent.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed size of messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence messages."
+          "description": "Total uncompressed size of messages sent by a HTTP trigger, excluding delta compression https://ably.com/docs/channels/options/deltas, typically a serverless function on a service such as AWS Lambda, Google Cloud Functions, or Azure Functions), excluding presence and state messages."
         },
         "messages.outbound.httpEvent.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages sent by a HTTP trigger excluding presence messages that failed (which were rejected by the external endpoint for some reason)"
+          "description": "Total number of messages sent by a HTTP trigger excluding presence and state messages that failed (which were rejected by the external endpoint for some reason)"
         },
         "messages.outbound.httpEvent.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of messages sent by a HTTP trigger excluding presence messages that Ably refused to send (generally due to a rate limit)"
+          "description": "Total number of messages sent by a HTTP trigger excluding presence and state messages that Ably refused to send (generally due to a rate limit)"
         },
         "messages.outbound.httpEvent.presence.count": {
           "type": "number",
@@ -904,27 +904,27 @@
         "messages.outbound.push.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Push message count (pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total Push message count (pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence and state messages."
         },
         "messages.outbound.push.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total Push message size (pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total Push message size (pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence and state messages."
         },
         "messages.outbound.push.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed Push message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence messages."
+          "description": "Total uncompressed Push message size, excluding delta compression https://ably.com/docs/channels/options/deltas, pushed to devices via a Push Notifications transport such as FCM or APNS), excluding presence and state messages."
         },
         "messages.outbound.push.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
+          "description": "Total number of Push messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by APNS or FCM, or a service issue on Ably's side)"
         },
         "messages.outbound.push.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of Push messages excluding presence messages that were refused by Ably (eg due to a rate limit)"
+          "description": "Total number of Push messages excluding presence and state messages that were refused by Ably (eg due to a rate limit)"
         },
         "messages.outbound.push.presence.count": {
           "type": "number",
@@ -984,32 +984,32 @@
         "messages.outbound.all.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound message count (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound message count (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.all.messages.billableCount": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total billable outbound message count (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total billable outbound message count (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.all.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total outbound message size (sent from the Ably service to clients), excluding presence messages."
+          "description": "Total outbound message size (sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.all.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed outbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+          "description": "Total uncompressed outbound message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence and state messages."
         },
         "messages.outbound.all.messages.failed": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages excluding presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
+          "description": "Total number of outbound messages excluding presence and state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as rejection by an external integration target, or a service issue on Ably's side)"
         },
         "messages.outbound.all.messages.refused": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total number of outbound messages excluding presence messages that were refused by Ably (generally due to rate limits)"
+          "description": "Total number of outbound messages excluding presence and state messages that were refused by Ably (generally due to rate limits)"
         },
         "messages.outbound.all.presence.count": {
           "type": "number",
@@ -1059,17 +1059,17 @@
         "messages.persisted.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total persisted message count based on configured channel rules, excluding presence messages."
+          "description": "Total persisted message count based on configured channel rules, excluding presence and state messages."
         },
         "messages.persisted.messages.data": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total persisted message size based on configured channel rules, excluding presence messages."
+          "description": "Total persisted message size based on configured channel rules, excluding presence and state messages."
         },
         "messages.persisted.messages.uncompressedData": {
           "type": "number",
           "inclusiveMinimum": 0,
-          "description": "Total uncompressed persisted message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules, excluding presence messages."
+          "description": "Total uncompressed persisted message size, excluding delta compression https://ably.com/docs/channels/options/deltas based on configured channel rules, excluding presence and state messages."
         },
         "messages.persisted.presence.count": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -293,6 +293,31 @@
           "inclusiveMinimum": 0,
           "description": "Total number of inbound REST presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
+        "messages.inbound.rest.state.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound REST state message count (received by the Ably service from clients)."
+        },
+        "messages.inbound.rest.state.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound REST state message size (received by the Ably service from clients)."
+        },
+        "messages.inbound.rest.state.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound REST state message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients."
+        },
+        "messages.inbound.rest.state.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST state messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)."
+        },
+        "messages.inbound.rest.state.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST state messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)."
+        },
         "messages.inbound.all.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -530,6 +555,26 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound REST presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.rest.state.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound REST state message count (sent from the Ably service to clients)."
+        },
+        "messages.outbound.rest.state.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total outbound REST state message size (sent from the Ably service to clients)."
+        },
+        "messages.outbound.rest.state.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed outbound REST state message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
+        },
+        "messages.outbound.rest.state.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of state messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter."
         },
         "messages.outbound.webhook.all.count": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -258,6 +258,16 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed inbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from clients, excluding presence messages."
         },
+        "messages.inbound.rest.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side), excluding presence & state messages."
+        },
+        "messages.inbound.rest.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound REST messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part), excluding presence & state messages."
+        },
         "messages.inbound.rest.presence.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -481,6 +491,11 @@
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients)."
         },
+        "messages.outbound.rest.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter."
+        },
         "messages.outbound.rest.messages.count": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -495,6 +510,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total uncompressed outbound REST message size, excluding delta compression https://ably.com/docs/channels/options/deltas, sent from the Ably service to clients), excluding presence messages."
+        },
+        "messages.outbound.rest.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of messages that would have been broadcast to realtime subscribers as a result of a REST publish attempt that was refused for breaching the account-wide message rate limiter, excluding presence & state messages"
         },
         "messages.outbound.rest.presence.count": {
           "type": "number",


### PR DESCRIPTION
This PR adds REST stat schema entries, both inbound and outbound for statemessages.

It also adds missing regular message entires and updates the description for the regular message to now say that presence and state messages are excluded from those stats.