### PR TITLE
Add HTTP method property to client events API request schema

### DIFF
--- a/json-schemas/src/client-events-api-requests.json
+++ b/json-schemas/src/client-events-api-requests.json
@@ -8,6 +8,10 @@
       "type": "string",
       "description": "The HTTP Host header of the API request."
     },
+    "method": {
+      "type": "string",
+      "description": "The HTTP Method of the API request."
+    },
     "requestId": {
       "type": "string",
       "description": "The unique ID of the API request that Ably can use to correlate a request event with internal logs, if necessary."


### PR DESCRIPTION
In support of exposing the HTTP method of Ably API requests in events.