### PR TITLE
chore: rename channel occupancy metrics

### DIFF
--- a/json-schemas/src/attachments.json
+++ b/json-schemas/src/attachments.json
@@ -55,8 +55,8 @@
             "metrics.presenceConnections",
             "metrics.presenceMembers",
             "metrics.presenceSubscribers",
-            "metrics.stateSubscribers",
-            "metrics.statePublishers"
+            "metrics.objectSubscribers",
+            "metrics.objectPublishers"
           ]
         }
       }


### PR DESCRIPTION
Rename the channel occupancy metrics to use objects instead of state. 