### PR TITLE
Add support for ably-cli in agents header

### DIFF
--- a/protocol/README.md
+++ b/protocol/README.md
@@ -93,6 +93,7 @@ The following table adds more contextual detail for some agent identifiers, wher
 | ---------- | -------- |
 | `ably-asset-tracking-android` | [ably-asset-tracking-android](https://github.com/ably/ably-asset-tracking-android) |
 | `ably-asset-tracking-swift` | [ably-asset-tracking-swift](https://github.com/ably/ably-asset-tracking-swift) |
+| `ably-cli` | [ably-cli command line CLI too](https://github.com/ably/cli) |
 | `ably-flutter` | [ably-flutter](https://github.com/ably/ably-flutter) |
 | `ably-ruby-rest` | [ably-ruby](https://github.com/ably/ably-ruby) |
 | `android` | [ably-java](https://github.com/ably/ably-java), [ably-dotnet](https://github.com/ably/ably-dotnet) |
@@ -144,6 +145,8 @@ Therefore it is safe to publish without consulting others because they have an e
 
 #### Step 2: Internal
 
+**Go router support**
+
 Once the generated Go code has been updated, update the `ably-common-go` module in the
 internal [go-services](https://github.com/ably/go-services) repository by running:
 
@@ -153,6 +156,10 @@ go get -u github.com/ably/ably-common-go
 
 Open a pull request with the resulting changes to `go.mod` and `go.sum`, and once merged deploy the router
 so that it's aware of the newly added agent identifiers.
+
+**Analytics pipeline support**
+
+The agents are replicated in the analytics pipeline that processes agent headers. See [udtf_parse_ably_agent.py](https://github.com/ably/infrastructure/blob/main/terraform/modules/analytics/snowflake/files/functions/udtf_parse_ably_agent.py). Notify the Data / Infrastructure team of the changes in `agents.json` so that support in the analytics data pipeine is added.
 
 ### `ablyLibMappings`
 

--- a/protocol/README.md
+++ b/protocol/README.md
@@ -76,8 +76,11 @@ When a new agent is added to a client library, add a corresponding entry to [age
 using the schema defined in [agents-schema.json](../json-schemas/src/agents.json), and open a pull
 request against the `main` branch with those changes.
 
-Once the pull request is merged into `main`, open an internal ticket requesting that the realtime team
-follow the "Publishing Changes" steps below.
+#### Analytics pipeline support
+
+The agents are replicated in the analytics pipeline that processes agent headers. See [udtf_parse_ably_agent.py](https://github.com/ably/infrastructure/blob/main/terraform/modules/analytics/snowflake/files/functions/udtf_parse_ably_agent.py).
+
+Once the pull request is merged into `main`, notify the Data / Infrastructure team of the changes to agents.json so that they can update the analytics data pipeine to support the newly added agents.
 
 ### Additional Notes on Agents
 
@@ -130,36 +133,6 @@ The following table adds more contextual detail for some agent identifiers, wher
 | `watchOS` | [ably-cocoa](https://github.com/ably/ably-cocoa) |
 | `windows` | [ably-dotnet](https://github.com/ably/ably-dotnet), [ably-go](https://github.com/ably/ably-go) |
 | `xamarin` | [ably-dotnet](https://github.com/ably/ably-dotnet) |
-
-### Publishing Changes
-
-#### Step 1: Public
-
-After changes to [agents.json](agents.json) have been merged into `main`, update the generated Go code
-in the [ably-common-go](https://github.com/ably/ably-common-go) repository by manually triggering the
-[publish workflow](../.github/workflows/publish.yml) (see [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
-for instructions on how to do that).
-
-There is no further, immediate downstream impact of publishing to `ably-common-go` like this.
-Therefore it is safe to publish without consulting others because they have an explicit step required to update the submodule in their codebase (see [Step 2: Internal](#step-2-internal)).
-
-#### Step 2: Internal
-
-**Go router support**
-
-Once the generated Go code has been updated, update the `ably-common-go` module in the
-internal [go-services](https://github.com/ably/go-services) repository by running:
-
-```bash
-go get -u github.com/ably/ably-common-go
-```
-
-Open a pull request with the resulting changes to `go.mod` and `go.sum`, and once merged deploy the router
-so that it's aware of the newly added agent identifiers.
-
-**Analytics pipeline support**
-
-The agents are replicated in the analytics pipeline that processes agent headers. See [udtf_parse_ably_agent.py](https://github.com/ably/infrastructure/blob/main/terraform/modules/analytics/snowflake/files/functions/udtf_parse_ably_agent.py). Notify the Data / Infrastructure team of the changes in `agents.json` so that support in the analytics data pipeine is added.
 
 ### `ablyLibMappings`
 

--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -364,6 +364,11 @@
       "identifier": "chat-swift",
       "versioned": true,
       "type": "wrapper"
+    },
+    {
+      "identifier": "ably-cli",
+      "versioned": true,
+      "type": "wrapper"
     }
   ],
   "ablyLibMappings": {


### PR DESCRIPTION
Note that describing the ably-cli as a wrapper is arguably not correct, it's an application or perhaps a tool, but adding support for a new type is probably a lot of work, and at this stage, has limited value given we simply want a way to track ably-cli usage. The reason it's not correct is in the context of the data plane, ably-cli is not providing an API to end users, and wrapping functionality in an SDK, it is just a tool or app consuming. When it's calling the control plane, then it's not really an SDK as it's just a tool calling the API directly, and it's not a wrapper as it's not wrapping anything. If I categorised ably-cli as an SDK, then we'd also have the problem that the underlying SDK would not be logged as I believe only one SDK value is supported in most reports. On balance, I think what I have chosen is correct, but open to feedback / suggestions.

This commit also adds instructions for future people who want to make changes to agents to make them aware that agents are duplicated in our analytics pipeline processing.

Once this PR is merged, two downstream actions are needed:

1) router to be updated and deployed
2) analytics pipeline to be updated to support the new ably-cli agent.