### PR TITLE
errors: add 93003 annotations not enabled

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -208,6 +208,7 @@
 
   "93001": "attempt to add an annotation listener without having requested the annotation_subscribe channel mode in ChannelOptions, which won't do anything (we only deliver annotations to clients who have explicitly requested them)",
   "93002": "Attempt to publish an annotation on a channel which isn't in a namespace which has Mutable Messages enabled",
+  "93003": "Annotations are not enabled for this channel or channel namespace",
 
   "101000": "must have a non-empty name for the space",
   "101001": "must enter a space to perform this operation",


### PR DESCRIPTION
Adds error code 93003 for when annotations is used when it has not been enabled on the channel or channel namespace.

See: https://github.com/ably/realtime/pull/7477