### PR TITLE
remove `react-hooks-time-ping` agent

### DIFF
--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -316,11 +316,6 @@
       "type": "wrapper"
     },
     {
-      "identifier": "react-hooks-time-ping",
-      "versioned": true,
-      "type": "wrapper"
-    },
-    {
       "identifier": "spaces",
       "versioned": true,
       "type": "wrapper"


### PR DESCRIPTION
no longer used, and superseded by per-attachment agents