### PR TITLE
Update stats schemas to include inbound externalQueue

### DIFF
--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -214,6 +214,131 @@
           "inclusiveMinimum": 0,
           "description": "Total number of inbound realtime object messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
+        "messages.inbound.externalQueue.all.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.all.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.all.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
+        "messages.inbound.externalQueue.messages.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.messages.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.messages.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
+        "messages.inbound.externalQueue.presence.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue presence message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.presence.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue presence message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.presence.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
+        "messages.inbound.externalQueue.objects.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue object message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.objects.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue object message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.objects.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue object message size received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.objects.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue object messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.objects.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue object messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
+        "messages.inbound.externalQueue.annotations.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue annotation message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.annotations.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue annotation message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.annotations.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue annotation message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.annotations.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue annotation messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.annotations.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue annotation messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
         "messages.inbound.rest.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -218,6 +218,131 @@
           "inclusiveMinimum": 0,
           "description": "Total number of inbound realtime object messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
         },
+        "messages.inbound.externalQueue.all.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.all.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.all.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.all.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.all.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
+        "messages.inbound.externalQueue.messages.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.messages.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.messages.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.messages.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.messages.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
+        "messages.inbound.externalQueue.presence.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue presence message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.presence.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue presence message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.presence.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue presence message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.presence.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue presence messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.presence.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue presence messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
+        "messages.inbound.externalQueue.objects.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue object message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.objects.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue object message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.objects.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue object message size received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.objects.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue object messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.objects.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue object messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
+        "messages.inbound.externalQueue.annotations.count": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue annotation message count (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.annotations.data": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total inbound external queue annotation message size (received by the Ably service from external queues)."
+        },
+        "messages.inbound.externalQueue.annotations.uncompressedData": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total uncompressed inbound external queue annotation message size, excluding delta compression https://ably.com/docs/channels/options/deltas, received by the Ably service from external queues."
+        },
+        "messages.inbound.externalQueue.annotations.failed": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue annotation messages that failed (which did not succeed for some reason other than Ably explicitly refusing it, such as a service issue on Ably's side)"
+        },
+        "messages.inbound.externalQueue.annotations.refused": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of inbound external queue annotation messages that were refused by Ably (eg due to a rate limit, a malformed message, or incorrect permissions on the client's part)"
+        },
         "messages.inbound.rest.all.count": {
           "type": "number",
           "inclusiveMinimum": 0,


### PR DESCRIPTION
Update app and account stats schemas to include inbound for externalQueue. These are used for ingress rules, e.g. messages published via a postgres or mongodb database connection.