### PR TITLE
Add error code 92008 for apply-on-ACK abandonment of wait-for-SYNCED

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -209,6 +209,7 @@
   "92005": "no objects found matching operation path",
   "92006": "unable to perform operation without objectId or path",
   "92007": "operation not processable on path",
+  "92008": "unable to apply objects operation; objects sync did not complete",
 
   "93001": "attempt to add an annotation listener without having requested the annotation_subscribe channel mode in ChannelOptions, which won't do anything (we only deliver annotations to clients who have explicitly requested them)",
   "93002": "unable to perform operation; this operation can only be performed on channel in a namespace with Mutable Messages enabled",


### PR DESCRIPTION
This is the code that a LiveObjects mutation operation will fail with if the channel enters `DETACHED`, `SUSPENDED`, or `FAILED` whilst waiting for the objects sync state to become `SYNCED`. See https://github.com/ably/specification/pull/419.
