### PR TITLE
Add error code 91006 for presence data size limit

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -199,6 +199,7 @@
   "91003": "unable to enter presence channel (maximum member limit exceeded)",
   "91004": "unable to automatically re-enter presence channel",
   "91005": "presence state is out of sync",
+  "91006": "unable to enter presence channel (maximum presence set data size exceeded)",
   "91100": "member implicitly left presence channel (connection closed)",
 
   "92000": "invalid object message",


### PR DESCRIPTION
## Summary
- Adds error code `91006`: "unable to enter presence channel (maximum presence set data size exceeded)"
- Used when a presence enter is rejected because it would exceed the maximum total data size of the presence set

🤖 Generated with [Claude Code](https://claude.com/claude-code)