### PR TITLE
Add error code 40035 for invalid messageFilter regex

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -33,6 +33,7 @@
   "40032": "Invalid publish request (impermissible extras field)",
   "40033": "Operation cancelled",
   "40034": "Invalid publish request (maximum number of messages per ChannelMessage exceeded)",
+  "40035": "integration rule messageFilter regex must be RE2-compatible; backreferences and lookaround aren't supported",
   "40099": "Reserved for artifical errors for testing",
 
   "40100": "unauthorized",


### PR DESCRIPTION
## Summary
- Adds error code 40035 for integration rule messageFilter regexes that aren't RE2-compatible (e.g. use backreferences or lookaround).

## Test plan
- [ ] N/A — JSON-only addition