### PR TITLE
Add ai-transport-js to the agent registry

### DIFF
--- a/json-schemas/src/agents.json
+++ b/json-schemas/src/agents.json
@@ -39,7 +39,8 @@
               "asset-tracking",
               "platform",
               "livesync",
-              "chat"
+              "chat",
+              "ai-transport"
             ]
           },
           "name": {

--- a/protocol/agents.json
+++ b/protocol/agents.json
@@ -672,6 +672,14 @@
       "name": "Chat React UI Kit"
     },
     {
+      "identifier": "ai-transport-js",
+      "versioned": true,
+      "type": "wrapper",
+      "source": "https://github.com/ably/ably-ai-transport-js",
+      "product": "ai-transport",
+      "name": "AI Transport Javascript"
+    },
+    {
       "identifier": "ably-cli",
       "versioned": true,
       "type": "wrapper",


### PR DESCRIPTION
Register the `ai-transport-js` wrapper agent (versioned) for the new `@ably/ai-transport` SDK at https://github.com/ably/ably-ai-transport-js. The SDK self-registers this identifier on the Realtime client's `options.agents` map at session construction so the Ably backend can attribute usage to it, in line with the pattern used by ably-chat-js.

Introduce a new `ai-transport` product category in the agents JSON schema enum to support the entry.