### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Read Tool Versions
         id: tool-versions
@@ -31,6 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Read Tool Versions
         id: tool-versions

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           persist-credentials: false
 
@@ -20,7 +20,7 @@ jobs:
         id: tool-versions
         run: echo "::set-output name=nodejs::$(sed -nr 's/nodejs ([0-9]+)/\1/p' .tool-versions)"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: ${{ steps.tool-versions.outputs.nodejs }}
 
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           persist-credentials: false
 
@@ -47,7 +47,7 @@ jobs:
         run: echo "::set-output name=golang::$(sed -nr 's/golang ([0-9]+)/\1/p' .tool-versions)"
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: ${{ steps.tool-versions.outputs.golang }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,9 +4,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
         with:
@@ -31,6 +35,8 @@ jobs:
 
   check-go:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-json-schemas.yml
+++ b/.github/workflows/publish-json-schemas.yml
@@ -10,6 +10,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/publish-json-schemas.yml
+++ b/.github/workflows/publish-json-schemas.yml
@@ -12,12 +12,12 @@ jobs:
       contents: read
       id-token: write # Required for OIDC assume-role into AWS
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           persist-credentials: false
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK}}:role/ably-sdk-schemas-ably-common
@@ -27,7 +27,7 @@ jobs:
         id: tool-versions
         run: echo "::set-output name=nodejs::$(sed -nr 's/nodejs ([0-9]+)/\1/p' .tool-versions)"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: ${{ steps.tool-versions.outputs.nodejs }}
 

--- a/.github/workflows/publish-json-schemas.yml
+++ b/.github/workflows/publish-json-schemas.yml
@@ -3,11 +3,14 @@
 
 on: workflow_dispatch
 
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      contents: read
+      id-token: write # Required for OIDC assume-role into AWS
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,13 @@
 
 on: workflow_dispatch
 
+permissions: {}
+
 jobs:
   publish-go:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Read Tool Versions
         id: tool-versions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           persist-credentials: false
 
@@ -20,7 +20,7 @@ jobs:
         run: echo "::set-output name=golang::$(sed -nr 's/golang ([0-9]+)/\1/p' .tool-versions)"
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
           go-version: ${{ steps.tool-versions.outputs.golang }}
 

--- a/.github/workflows/sync-to-s3.yml
+++ b/.github/workflows/sync-to-s3.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/sync-to-s3.yml
+++ b/.github/workflows/sync-to-s3.yml
@@ -24,12 +24,12 @@ jobs:
       id-token: write # Required for OIDC assume-role into AWS
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "18"
           cache: "npm"
@@ -55,7 +55,7 @@ jobs:
           npm run fetch:agent-releases
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK}}:role/ably-sdk-schemas-ably-common

--- a/.github/workflows/sync-to-s3.yml
+++ b/.github/workflows/sync-to-s3.yml
@@ -14,14 +14,14 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch: # Allow manual trigger
 
-permissions:
-  id-token: write # Required for OIDC
-  contents: read
+permissions: {}
 
 jobs:
   generate-and-sync:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      id-token: write # Required for OIDC assume-role into AWS
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

- Disable credential persistence on actions/checkout steps so the default GITHUB_TOKEN is not left in the local git config after checkout.
- Scope each workflow's permissions explicitly: top-level permissions: {}, with each job granted only the GITHUB_TOKEN scopes it actually needs (contents: read, plus id-token: write
where OIDC is used to assume an AWS role).
- Pin all third-party actions to commit SHAs (with the major-version tag preserved as a trailing comment) so an upstream tag move can't silently change what runs in CI.
 
No behavioural changes intended - the workflows run the same steps against the same inputs, no version bumps.