### PR TITLE
Add error code 40025 for APIs that are no longer supported

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -28,6 +28,7 @@
   "40022": "API Streamer has been shut down",
   "40023": "Action requires a newer protocol version",
   "40024": "unable to get channel history (incompatible site)",
+  "40025": "API no longer supported",
   "40030": "Invalid publish request (unspecified)",
   "40031": "Invalid publish request (invalid client-specified id)",
   "40032": "Invalid publish request (impermissible extras field)",


### PR DESCRIPTION
## Summary
- Adds a new generic error code `40025: "API no longer supported"` to `protocol/errors.json`, placed alongside the existing version/compatibility codes (40021, 40023, 40024).

## Why
Requested in [ably-js#2226](https://github.com/ably/ably-js/pull/2226) review feedback. That PR re-introduces the deleted v1 callback-style APIs in a deprecated form, throwing synchronously to nudge LLMs/users toward the v2 promise-based APIs. It currently raises ErrorInfo with code `40000` ("bad request"), which is generic and overused.

A dedicated code:
- Gives LLMs a unique signal to disambiguate this class of error.
- Sets precedent for future deprecation/removals, rather than continuing to overload `40000`.

The wording is intentionally generic ("API no longer supported") so future deprecations can reuse it.

## Test plan
- [ ] No code change beyond the JSON entry; CI lint/schema checks should pass.
- [ ] Downstream consumer (ably-js PR #2226) updates to reference `40025`.