### PR TITLE
Add AI Transport SDK error codes (104000-104011)

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -254,5 +254,17 @@
   "103000": "unable to publish push notification",
   "103001": "unable to publish push notification, retries exhausted",
   "103002": "unable to publish push notification, no recipient for direct publish",
-  "103003": "unable to publish push notification, cannot handle body"
+  "103003": "unable to publish push notification, cannot handle body",
+
+  "104000": "encoder recovery failed after flush",
+  "104001": "transport subscription callback error",
+  "104002": "cancel listener error",
+  "104003": "turn lifecycle event publish failed",
+  "104004": "transport is closed",
+  "104005": "transport send failed",
+  "104006": "channel continuity lost",
+  "104007": "channel is not ready",
+  "104008": "source event stream failed during piping",
+  "104009": "run start deadline exceeded",
+  "104010": "user prompt not found within lookup deadline"
 }

--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -266,5 +266,6 @@
   "104007": "channel is not ready",
   "104008": "source event stream failed during piping",
   "104009": "run start deadline exceeded",
-  "104010": "user prompt not found within lookup deadline"
+  "104010": "user prompt not found within lookup deadline",
+  "104011": "channel history fetch failed"
 }


### PR DESCRIPTION
Register the AI Transport SDK's 104xxx custom error codes so SDK
validation against this registry passes. The codes cover SDK-specific
scenarios that don't map cleanly to existing entries:

- 104000-104008 — encoder recovery, transport lifecycle, channel
  continuity, stream piping (added with earlier branches).
- 104010 "run start deadline exceeded" — client send() did not
  observe x-ably-run-start within the configured deadline.
- 104011 "user prompt not found within lookup deadline" — agent's
  channel-rewind lookup for the client-published user message
  lapsed without a match.

Capability failures reuse Ably's existing 40160 ("operation not
permitted with provided capability") rather than coining a new code.