### PR TITLE
Reserve error codes 90009 and 91008 for SDK silent-failure surfacing

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -204,6 +204,7 @@
   "90006": "unable to recover channel (unbounded request)",
   "90007": "channel operation failed (no response from server)",
   "90008": "unable to get channel history (attach point not found)",
+  "90009": "messages not delivered to subscriber (channel attached without the subscribe mode)",
   "90010": "maximum number of channels per connection/request exceeded",
   "90021": "exceeded maximum permitted account-wide rate of creating new channels",
   "91000": "unable to enter presence channel (no clientId)",
@@ -214,6 +215,7 @@
   "91005": "presence state is out of sync",
   "91006": "unable to enter presence channel (maximum presence set data size exceeded)",
   "91007": "Unexpected loss of presence membership",
+  "91008": "unable to retrieve presence members (channel attached without the presence_subscribe mode)",
   "91100": "member implicitly left presence channel (connection closed)",
 
   "92000": "invalid object message",


### PR DESCRIPTION
## Summary

[ably-js#2236](https://github.com/ably/ably-js/pull/2236) (DX-1211) surfaces two previously-silent SDK failures as hinted `ErrorInfo`s and needs client-side error codes for them:

- `presence.get()` on a channel attached without the `presence_subscribe` mode (returns `[]` today)
- `channel.subscribe()` on a channel attached without the `subscribe` mode (listener never fires today)

That PR initially minted `93002` (presence) and `93003` (subscribe). **`93002` collides** with the existing server-emitted code — _"this operation can only be performed on a channel in a namespace with Mutable Messages enabled"_ (documented at `faqs.ably.com/error-code-93002`) — and `93xxx` is the annotations / mutable-messages block.

This PR reserves the two codes in their correct subsystem blocks so they are unique platform-wide, mirroring how `93001` is already registered for the annotation mode-check.

## Codes added

| Code | Block | Meaning |
| --- | --- | --- |
| `90009` | channel (`90xxx`) | `channel.subscribe()` without the `subscribe` mode — messages not delivered to the subscriber |
| `91008` | presence (`91xxx`) | `presence.get()` without the `presence_subscribe` mode — members not delivered to the client |

`errorsHelp.json` FAQ links can follow once the pages exist; they are not required for reservation. These are SDK client-side codes (like `93001`), not server-emitted.

## Related

- ably-js: https://github.com/ably/ably-js/pull/2236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
