### PR TITLE
errors: add 80025 for exceeded max concurrent connections per token

### DIFF
--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -181,6 +181,7 @@
   "80022": "unable to continue current comet connection",
   "80023": "unable to resume connection from a different site",
   "80024": "protocol version is no longer supported",
+  "80025": "exceeded maximum concurrent connections permitted for this token",
   "80030": "client restriction not satisfied",
 
   "90000": "channel operation failed",


### PR DESCRIPTION
## Summary

- Adds error code `80025`: "exceeded maximum concurrent connections permitted for this token".

## Why

The realtime platform measures (and can enforce) a limit on the number of concurrent connections sharing a single auth token. There was no dedicated error code for this case.

The existing nodejs implementation (`common/lib/security/authparams.ts`) reuses `80019` for it — but `80019` actually means *"client configured authentication provider request failed"*, an unrelated client-side auth error that SDKs may react to by retrying authentication. Surfacing it for a server-side concurrency limit is misleading.

`80025` is the next free code in the contiguous connection-error block (`800xx`). Once this merges, the realtime repo will switch the nodejs check to `80025` and the in-progress Go frontdoor implementation (PUB-1503) will use it too.

No `errorsHelp.json` entry is added, as no FAQ article exists for this code yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)