### PR TITLE
Register Live Activity push-to-start error code 40182, add LiveActivity push stats

### DIFF
--- a/errors/codes/40180.md
+++ b/errors/codes/40180.md
@@ -1,6 +1,6 @@
 ---
 code: 40180
-identifier: apns_token_authentication_required
-title: APNs token authentication required
-summary: A location or live-activity notification was not sent because these require the app's APNs credentials to use token-based authentication, but the app is not configured that way.
+identifier: apns_token_authentication_required_for_location
+title: APNs token authentication required for location notification
+summary: A location notification was not sent because location notifications require the app's APNs credentials to use token-based authentication, but the app is not configured that way.
 ---

--- a/errors/codes/40182.md
+++ b/errors/codes/40182.md
@@ -1,0 +1,6 @@
+---
+code: 40182
+identifier: apns_token_authentication_required_for_push_to_start
+title: APNs token authentication required for push-to-start Live Activities notification
+summary: A live-activity push-to-start notification was not sent because push-to-start requires the app's APNs credentials to use token-based authentication, but the app is not configured that way.
+---

--- a/json-schemas/src/account-stats.json
+++ b/json-schemas/src/account-stats.json
@@ -1524,6 +1524,11 @@
           "inclusiveMinimum": 0,
           "description": "Total number of successfully-delivered APNS location Push notifications."
         },
+        "push.notifications.delivered.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of successfully-delivered APNS Live Activity Push notifications."
+        },
         "push.notifications.delivered.apnsAlert": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -1558,6 +1563,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of APNS location Push notifications that Ably attempted to deliver but were refused with a retriable error (so which Ably will attempt to retry)."
+        },
+        "push.notifications.refused.retriable.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of APNS Live Activity Push notifications that Ably attempted to deliver but were refused with a retriable error (so which Ably will attempt to retry)."
         },
         "push.notifications.refused.retriable.apnsAlert": {
           "type": "number",
@@ -1594,6 +1604,11 @@
           "inclusiveMinimum": 0,
           "description": "Total number of APNS location Push notifications that Ably attempted to deliver but were refused with a non-retriable error."
         },
+        "push.notifications.refused.final.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of APNS Live Activity Push notifications that Ably attempted to deliver but were refused with a non-retriable error."
+        },
         "push.notifications.refused.final.apnsAlert": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -1618,6 +1633,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of APNS location Push notifications that Ably did not attempt to deliver, for example APNS location push notifications sent over a channel to subscribing devices without location tokens."
+        },
+        "push.notifications.skipped.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of APNS Live Activity Push notifications that Ably did not attempt to deliver, for example Live Activity push-to-start notifications sent to devices without push-to-start tokens."
         },
         "push.notifications.skipped.apnsAlert": {
           "type": "number",
@@ -1649,6 +1669,11 @@
           "inclusiveMinimum": 0,
           "description": "Total number of attempts (whatever the outcome) to deliver APNS location Push notifications."
         },
+        "push.notifications.all.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of attempts (whatever the outcome) to deliver APNS Live Activity Push notifications."
+        },
         "push.notifications.all.apnsAlert": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -1668,6 +1693,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of direct push publishes (that is, notifications triggered by a request to /push/publish, not a channel message with a push payload)."
+        },
+        "push.apnsBroadcasts": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of APNs Live Activity broadcasts issued. Each broadcast is a single request to Apple that Apple fans out to every device subscribed to the broadcast channel (Ably has no per-device visibility), so this counts issuance, not deliveries. Includes the final broadcast sent by an end request."
         },
         "peakRates.messages": {
           "type": "number",

--- a/json-schemas/src/app-stats.json
+++ b/json-schemas/src/app-stats.json
@@ -1529,6 +1529,11 @@
           "inclusiveMinimum": 0,
           "description": "Total number of successfully-delivered APNS location Push notifications."
         },
+        "push.notifications.delivered.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of successfully-delivered APNS Live Activity Push notifications."
+        },
         "push.notifications.delivered.apnsAlert": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -1563,6 +1568,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of APNS location Push notifications that Ably attempted to deliver but were refused with a retriable error (so which Ably will attempt to retry)."
+        },
+        "push.notifications.refused.retriable.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of APNS Live Activity Push notifications that Ably attempted to deliver but were refused with a retriable error (so which Ably will attempt to retry)."
         },
         "push.notifications.refused.retriable.apnsAlert": {
           "type": "number",
@@ -1599,6 +1609,11 @@
           "inclusiveMinimum": 0,
           "description": "Total number of APNS location Push notifications that Ably attempted to deliver but were refused with a non-retriable error."
         },
+        "push.notifications.refused.final.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of APNS Live Activity Push notifications that Ably attempted to deliver but were refused with a non-retriable error."
+        },
         "push.notifications.refused.final.apnsAlert": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -1623,6 +1638,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of APNS location Push notifications that Ably did not attempt to deliver, for example APNS location push notifications sent over a channel to subscribing devices without location tokens."
+        },
+        "push.notifications.skipped.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of APNS Live Activity Push notifications that Ably did not attempt to deliver, for example Live Activity push-to-start notifications sent to devices without push-to-start tokens."
         },
         "push.notifications.skipped.apnsAlert": {
           "type": "number",
@@ -1654,6 +1674,11 @@
           "inclusiveMinimum": 0,
           "description": "Total number of attempts (whatever the outcome) to deliver APNS location Push notifications."
         },
+        "push.notifications.all.apnsLiveActivity": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of attempts (whatever the outcome) to deliver APNS Live Activity Push notifications."
+        },
         "push.notifications.all.apnsAlert": {
           "type": "number",
           "inclusiveMinimum": 0,
@@ -1673,6 +1698,11 @@
           "type": "number",
           "inclusiveMinimum": 0,
           "description": "Total number of direct push publishes (that is, notifications triggered by a request to /push/publish, not a channel message with a push payload)."
+        },
+        "push.apnsBroadcasts": {
+          "type": "number",
+          "inclusiveMinimum": 0,
+          "description": "Total number of APNs Live Activity broadcasts issued. Each broadcast is a single request to Apple that Apple fans out to every device subscribed to the broadcast channel (Ably has no per-device visibility), so this counts issuance, not deliveries. Includes the final broadcast sent by an end request."
         }
       }
     }

--- a/protocol/errors.json
+++ b/protocol/errors.json
@@ -383,14 +383,19 @@
       "summary": "The operation was refused because it can only be performed with Token authentication, but the client authenticated using Basic authentication. Some operations are available only to clients using a token."
     },
     "40180": {
-      "identifier": "apns_token_authentication_required",
-      "title": "APNs token authentication required",
-      "summary": "A location or live-activity notification was not sent because these require the app's APNs credentials to use token-based authentication, but the app is not configured that way."
+      "identifier": "apns_token_authentication_required_for_location",
+      "title": "APNs token authentication required for location notification",
+      "summary": "A location notification was not sent because location notifications require the app's APNs credentials to use token-based authentication, but the app is not configured that way."
     },
     "40181": {
       "identifier": "no_location_token_for_device",
       "title": "No location token for device",
       "summary": "A location push notification was not sent to a device because the device has no location token registered. Location notifications can only be delivered to devices that have supplied one."
+    },
+    "40182": {
+      "identifier": "apns_token_authentication_required_for_push_to_start",
+      "title": "APNs token authentication required for push-to-start Live Activities notification",
+      "summary": "A live-activity push-to-start notification was not sent because push-to-start requires the app's APNs credentials to use token-based authentication, but the app is not configured that way."
     },
     "40300": {
       "identifier": "forbidden",


### PR DESCRIPTION
## Summary

ably-common side of LiveActivity production readiness ([ADR-157](https://ably.atlassian.net/wiki/spaces/ENG/pages/4848779315), [follow-up](https://ably.atlassian.net/wiki/spaces/ENG/pages/5096734732)): registers the one LiveActivity error code still missing from the error registry, and adds the customer stats for Live Activity broadcasts and per-outcome notification delivery. Unblocks [ably/realtime#8527](https://github.com/ably/realtime/pull/8527), which bumps its ably-common submodule once this merges.

Restructured after #348 ("Error code documentation registry"): codes are now registered as `errors/codes/<code>.md` files and `protocol/errors.json` is generated from them. Of the six codes this PR originally set out to add, #344 had already registered 103004–103007 and #348 registered 103008 — leaving only 40182.

## Error code

- **`errors/codes/40182.md`** (new) — `apns_token_authentication_required_for_push_to_start`. Push-to-start of a Live Activity requires the app's APNs credentials to use token-based authentication. realtime#8527 rejects non-compliant apps with 40182 at `/start` request time and uses it for the push-worker transport skip (both previously fell under location's 40180).
- **`errors/codes/40180.md`** — scoped back to location notifications only, since realtime#8527 moves the live-activity case onto 40182: summary narrowed, and identifier/title renamed to `apns_token_authentication_required_for_location` / "APNs token authentication required for location notification" so the pair reads symmetrically (per review). There's a brief window between the two merges where production still emits 40180 for live-activity skips; realtime#8527 closes it.
- **`protocol/errors.json`** — regenerated via `npm run generate:errors` (not hand-edited).

## Stats schema

Adds `push.apnsBroadcasts` to `json-schemas/src/app-stats.json` and `json-schemas/src/account-stats.json`, alongside `push.directPublishes`. Each broadcast is a single request to Apple that Apple fans out to every subscribed device (Ably has no per-device visibility), so the counter tracks issuance, not deliveries, and includes the final broadcast sent by an end request.

Also adds the ten per-outcome entries `push.notifications.{delivered,refused.retriable,refused.final,skipped,all}.apnsLiveActivity` to both schemas, mirroring the `apnsLocation` wording and placement. These are emitted by the push-worker's `apnsLiveActivity` stats block in ably/realtime#8527, which counts the expected no-push-to-start-token drops as skips.

Additive fields only — no `versions.json` bump, following 50412f0 ("Add missing objects stats").

## Related

- [AIT-989](https://ably.atlassian.net/browse/AIT-989) — error-code registration
- [AIT-990](https://ably.atlassian.net/browse/AIT-990) — stats counters
- [AIT-804](https://ably.atlassian.net/browse/AIT-804) — 40182 push-to-start precondition
- [ably/realtime#8527](https://github.com/ably/realtime/pull/8527) — realtime side (merge this PR first, then the submodule bump lands there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIT-989]: https://ably.atlassian.net/browse/AIT-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ